### PR TITLE
Adding promo_image and promo_images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,3 @@ First, make sure you can build and validate all the current schemas.
 ** speaking of that, since "content" has "ans", I assume I can just list "content" as a property, right?
 * What about traits like "skedable", "categorizable" or "trackable"?  Should that be a free-form, optional string field somewhere? or an enum?
 * Should I switch all the "additionalProperties: false" to be "true"?  Or keep the ANS schema strict and allow for "wrapper" schemas that allow whatever they want to be tacked on 'around' the underlying schema?
-* Why does the TestStory unit test case fail when I add a promo image to the story-fixture-good.json file?
-```
-"promo_image": {
-        "content": {
-            "id": "unique ANS id",
-            "created_date": "2015-06-25T09:50:50.52Z",
-            "credit": [
-                {
-                    "name": "Ansel Adams",
-                    "role": "Photographer"
-                }
-            ]
-        },
-        "image_url": "https://tinyurl.com/mqyonhb",
-        "caption": "Never gonna give you up",
-        "subtitle": "Never gonna let you down",
-        "width": 800,
-        "height": 640
-    },
-
-error 
-=====
-com.github.fge.jsonschema.core.exceptions.InvalidSchemaException: fatal: invalid JSON Schema, cannot continue
-Syntax errors:
-[ {
-  "level" : "error",
-  "message" : "array must have at least one element",
-  "domain" : "syntax",
-  "schema" : {
-    "loadingURI" : "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/v0_2/image.json#",
-    "pointer" : ""
-  },
-  "keyword" : "required"
-} ]
-
-```

--- a/src/main/resources/schema/ans/v0_2/story.json
+++ b/src/main/resources/schema/ans/v0_2/story.json
@@ -66,12 +66,12 @@
         },
         "publish_date": {
             "type": "string",
-            "format": "datetime",
+            "format": "date-time",
             "description": "When the story was first published."
         },
         "display_date": {
             "type": "string",
-            "format": "datetime",
+            "format": "date-time",
             "description": "FIXME - what is the definition of this field?"
         },
         "html": {

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_2/model/story-fixture-good.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_2/model/story-fixture-good.json
@@ -7,7 +7,7 @@
             {
                 "name": "Bob Woodward",
                 "role": "Author",
-                "organization": "The Washington Post"
+                "org": "The Washington Post"
             }
         ]
     },
@@ -21,6 +21,42 @@
         {
             "id": "some other unique ANS id",
             "created_date": "2015-06-24T09:50:50.52Z"
+        }
+    ],
+    "promo_image": {
+        "content": {
+            "id": "unique ANS id",
+            "created_date": "2015-06-25T09:50:50.52Z",
+            "credit": [
+                {
+                    "name": "Ansel Adams",
+                    "role": "Photographer"
+                }
+            ]
+        },
+        "image_url": "https://tinyurl.com/mqyonhb",
+        "caption": "Never gonna give you up",
+        "subtitle": "Never gonna let you down",
+        "width": 800,
+        "height": 640
+    },
+    "promo_images": [
+        {
+            "content": {
+                "id": "unique ANS id",
+                "created_date": "2015-06-25T09:50:50.52Z",
+                "credit": [
+                    {
+                        "name": "Ansel Adams",
+                        "role": "Photographer"
+                    }
+                ]
+            },
+            "image_url": "https://tinyurl.com/mqyonhb",
+            "caption": "Never gonna give you up",
+            "subtitle": "Never gonna let you down",
+            "width": 800,
+            "height": 640
         }
     ],
     "taxonomy": "tbd",


### PR DESCRIPTION
I think the problem I was encountering previously was that the validator
was pulling down old schemas from github instead of the schemas on my
local filesystem.

This makes for some interesting (shitty) development environments
because it means you often have to commit schema changes you're not sure
work until you commit them....  seems like we need some branching
workflow to improve this, but it would mean changing the URLs in all the
schemas...