### PR TITLE
Configuring Jackson to re-use existing "type" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest version of the ANS schema is the 0.3.0-SNAPSHOT release, which includ
 <dependency>
     <groupId>com.washingtonpost.arc.ans</groupId>
     <artifactId>ans-schema</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.2</version>
 </dependency>
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@
 
 ## 0.4.0 TBD Release Date
 
+## 0.3.2 2015/09/28
+
+* Really fixing bug where the "type" attribute was being deserialized twice. The fix put in the 0.3.1 release technically works, but is incompatible with some other Jackson/Mongo frameworks being used "downstream" of this artifact.
+* Renaming Video.type to Video.videoType and VideoStream.type to VideoStream.streamType to avoid ambiguity about what "Video.type" refers to (answer: it should be the ANS type of the Video object)
+
 ## 0.3.1 2015/09/25
 
 * Fix bug where the "type" attribute was being deserialized into JSON twice.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.washingtonpost.arc.ans</groupId>
     <artifactId>ans-schema</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ans-schema</name>

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/ANS.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/ANS.java
@@ -1,6 +1,5 @@
 package com.washingtonpost.arc.ans.v0_3.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -15,31 +14,38 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.PROPERTY,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "type",
     visible = true)
 @JsonSubTypes({
-    @Type(value = ANS.class, name = "ans"),
-    @Type(value = Content.class, name = "content"),
-    @Type(value = Gallery.class, name = "gallery"),
-    @Type(value = Image.class, name = "image"),
-    @Type(value = Media.class, name = "media"),
-    @Type(value = Story.class, name = "story"),
-    @Type(value = Text.class, name = "text"),
-    @Type(value = Video.class, name = "video")
+    @Type(value = ANS.class, name = ANS.TYPE),
+    @Type(value = Content.class, name = Content.TYPE),
+    @Type(value = Gallery.class, name = Gallery.TYPE),
+    @Type(value = Image.class, name = Image.TYPE),
+    @Type(value = Media.class, name = Media.TYPE),
+    @Type(value = Story.class, name = Story.TYPE),
+    @Type(value = Text.class, name = Text.TYPE),
+    @Type(value = Video.class, name = Video.TYPE)
 })
 public class ANS implements TraitTyped, TraitId {
+
+    public static final String TYPE = "ans";
 
     // Globally unique ID
     @JsonProperty("_id")
     private String id;
     
     // The runtime type of this object (see getter/setter for implementation details)
-    @JsonIgnore
+    @JsonProperty("type")
     private String type;
 
+    // The version of the ANS specification this class/JSON conforms to
     @JsonProperty("version")
     private ANSVersion version;
+
+    public ANS() {
+        setType(TYPE);
+    }
 
     /**
      * @return The globally unique ID of this ANS object
@@ -58,21 +64,16 @@ public class ANS implements TraitTyped, TraitId {
     }
 
     /**
-     * Use @JsonIgnore here to avoid having 2 "type":"foo" strings in serialized JSON
-     * See https://stackoverflow.com/questions/18237222/duplicate-json-field-with-jackson
      * @return The concrete type of this ANS object
      */
-    @JsonIgnore
     @Override
     public String getType() {
         return type;
     }
 
     /**
-     * Define @JsonProperty("type") here to enable deserialization to save into a field our application code can access
      * @param type The concrete type of this ANS object
      */
-    @JsonProperty("type")
     @Override
     public void setType(String type) {
         this.type = type;

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Content extends ANS implements TraitDated, TraitCredited, TraitLocale, TraitLocated, TraitCopyrighted {
 
+    public static final String TYPE = "content";
     private Date createdDate;
     private Date lastUpdatedDate;
     private List<Credit> credits;
@@ -32,6 +33,10 @@ public class Content extends ANS implements TraitDated, TraitCredited, TraitLoca
 
     @JsonIgnore
     private final Map<String, Object> additionalProperties = new HashMap<>();
+
+    public Content() {
+        setType(TYPE);
+    }
 
     @Override
     public Date getCreatedDate() {

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Gallery.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Gallery.java
@@ -14,6 +14,12 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Gallery extends Collection {
 
+    public static final String TYPE = "ans";
+
+    public Gallery() {
+        setType(TYPE);
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Image.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Image.java
@@ -17,6 +17,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Image extends Media {
 
+    public static final String TYPE = "image";
+
     @JsonProperty("subtitle")
     private String subtitle;
 
@@ -31,6 +33,10 @@ public class Image extends Media {
 
     @JsonProperty("width")
     private int width;
+
+    public Image() {
+        setType(TYPE);
+    }
 
     /**
      * @return Subtitle for the image.

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Media.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Media.java
@@ -17,11 +17,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Media extends Content {
 
+    public static final String TYPE = "media";
+
     @JsonProperty("title")
     private String title;
 
     @JsonProperty("taxonomy")
     private Taxonomy taxonomy;
+
+
+    public Media() {
+        setType(TYPE);
+    }
 
     /**
      * @return The title of the media object

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Story.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Story.java
@@ -14,6 +14,12 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Story extends Collection {
 
+    public static final String TYPE = "story";
+
+    public Story() {
+        setType(TYPE);
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Text.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Text.java
@@ -10,9 +10,14 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 public class Text extends ANS {
 
+    public static final String TYPE = "text";
+
     @JsonProperty("text")
     private String text;
 
+    public Text() {
+        setType(TYPE);
+    }
     /**
      * @return The text of the element
      */

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Video.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Video.java
@@ -17,6 +17,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Video extends Media {
 
+    public static final String TYPE = "video";
+
     @JsonProperty("description")
     private String description;
 
@@ -29,8 +31,8 @@ public class Video extends Media {
     @JsonProperty("rating")
     private String rating;
 
-    @JsonProperty("type")
-    private String type;
+    @JsonProperty("videoType")
+    private String videoType;
 
     @JsonProperty("youtubeContentId")
     private String youtubeContentId;
@@ -40,6 +42,11 @@ public class Video extends Media {
 
     @JsonProperty("promo_image")
     private Image promoImage;
+
+
+    public Video() {
+        setType(TYPE);
+    }
 
     /**
      * @return Description for the video.
@@ -100,15 +107,15 @@ public class Video extends Media {
     /**
      * @return The type of video (e.g. clip, livestream, etc)
      */
-    public String getType() {
-        return type;
+    public String getVideoType() {
+        return videoType;
     }
 
     /**
-     * @param type The type of video (e.g. clip, livestream, etc)
+     * @param videoType The type of video (e.g. clip, livestream, etc)
      */
-    public void setType(String type) {
-        this.type = type;
+    public void setVideoType(String videoType) {
+        this.videoType = videoType;
     }
 
     /**
@@ -168,7 +175,7 @@ public class Video extends Media {
                 .append(this.rating)
                 .append(this.streams)
                 .append(this.transcript)
-                .append(this.type)
+                .append(this.videoType)
                 .append(this.youtubeContentId)
                 .appendSuper(super.hashCode())
                 .toHashCode();
@@ -190,7 +197,7 @@ public class Video extends Media {
                 .append(this.rating, rhs.rating)
                 .append(this.streams, rhs.streams)
                 .append(this.transcript, rhs.transcript)
-                .append(this.type, rhs.type)
+                .append(this.videoType, rhs.videoType)
                 .append(this.youtubeContentId, rhs.youtubeContentId)
                 .appendSuper(super.equals(other))
                 .isEquals();

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/VideoStream.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/VideoStream.java
@@ -48,11 +48,11 @@ public class VideoStream {
     @JsonProperty("videoCodec")
     private String videoCodec;
     /**
-     * The type of video (e.g. mp4).
+     * The type of video stream (e.g. mp4).
      * 
      */
-    @JsonProperty("type")
-    private String type;
+    @JsonProperty("streamType")
+    private String streamType;
     /**
      * Where to get the stream from.
      * 
@@ -183,25 +183,25 @@ public class VideoStream {
     }
 
     /**
-     * The type of video (e.g. mp4).
+     * The type of video stream (e.g. mp4).
      * 
      * @return
      *     The type
      */
-    @JsonProperty("type")
-    public String getType() {
-        return type;
+    @JsonProperty("streamType")
+    public String getStreamType() {
+        return streamType;
     }
 
     /**
-     * The type of video (e.g. mp4).
+     * The type of video stream (e.g. mp4).
      * 
-     * @param type
-     *     The type
+     * @param streamType
+     *     The streamType
      */
-    @JsonProperty("type")
-    public void setType(String type) {
-        this.type = type;
+    @JsonProperty("streamType")
+    public void setStreamType(String streamType) {
+        this.streamType = streamType;
     }
 
     /**
@@ -283,7 +283,7 @@ public class VideoStream {
                 .append(filesize)
                 .append(audioCodec)
                 .append(videoCodec)
-                .append(type)
+                .append(streamType)
                 .append(url)
                 .append(bitrate)
                 .append(provider)
@@ -305,7 +305,7 @@ public class VideoStream {
                 .append(filesize, rhs.filesize)
                 .append(audioCodec, rhs.audioCodec)
                 .append(videoCodec, rhs.videoCodec)
-                .append(type, rhs.type)
+                .append(streamType, rhs.streamType)
                 .append(url, rhs.url)
                 .append(bitrate, rhs.bitrate)
                 .append(provider, rhs.provider)

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractANSTest.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractANSTest.java
@@ -1,7 +1,10 @@
 package com.washingtonpost.arc.ans.v0_3.model;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 /**
@@ -19,5 +22,22 @@ public abstract class AbstractANSTest<T> extends AbstractTest<T> {
                 .suppress(Warning.STRICT_INHERITANCE, Warning.NONFINAL_FIELDS)
                 .withRedefinedSuperclass()
                 .verify();
+    }
+
+    /**
+     * <p>At first glance this test seems to just be testing an axiom like "foo.setX(1).getX() == 1" but it's designed to make
+     * sure application engineers who extend the object model below the ANS root object remember to define a distinct type and
+     * set that TYPE on their type field; this is important for downstream users of our ANS JAR such as Jackson (de)serializers
+     * and Mongojack frameworks.</p>
+     * @throws Exception
+     */
+    @Test
+    public void testTypeIsSetCorrectly() throws Exception {
+        Field typeField = getTargetClass().getField("TYPE");
+        Method getTypeMethod = getTargetClass().getMethod("getType");
+        Object ansObject = getTargetClass().newInstance();
+        String declaredType = (String)typeField.get(ansObject);
+
+        assertEquals(declaredType, getTypeMethod.invoke(ansObject));
     }
 }

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStory.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStory.java
@@ -94,7 +94,8 @@ public class TestStory extends AbstractANSTest<Story> {
      * <p>After the 0.3.0 release, we noticed sometimes we'd get JSON blocks of Story objects that had 2 separate "type":"story"
      * elements in them.  We suspect that's due to there being an explicit Ans.type field with a JSON in addition to the
      * "JsonTypeInfo" annotation at the class-level.  This test stresses that theory, and then verifies the fix.</p>
-     * <p>The fix, FWIW is: https://stackoverflow.com/questions/18237222/duplicate-json-field-with-jackson</p>
+     * <p>The fix, FWIW is explicitly setting the type of each object in its constructor and using the
+     * "JsonTypeInfo.As.EXISTING_PROPERTY" value in the ANS.java's @JsonTypeInfo setup</p>
      * @throws java.lang.Exception
      */
     @Test

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestVideo.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestVideo.java
@@ -26,10 +26,11 @@ public class TestVideo extends AbstractANSTest<Video> {
     public void testVideoGood() throws Exception {
         testJsonValidation("video-fixture-good", true);
         Video video = testClassSerialization("video-fixture-good");
+        assertThat(video.getType(), is("video"));
         assertThat(video.getDescription(), startsWith("We went out in 25+ knots"));
         assertThat(video.getCopyright(), is("(c) 2015, The Washington Post, Inc"));
         assertThat(video.getRating(), is("graphic"));
-        assertThat(video.getType(), is("clip"));
+        assertThat(video.getVideoType(), is("clip"));
         assertThat(video.getYoutubeContentId(), is("nKW3wvhnZoE"));
         assertThat(video.getDuration(), is(139000L));
         assertThat(video.getTranscript(), startsWith("This is a transcript of all the words said in the video."));
@@ -38,7 +39,7 @@ public class TestVideo extends AbstractANSTest<Video> {
         assertThat(video.getStreams().get(0).getHeight(), is(360));
         assertThat(video.getStreams().get(0).getWidth(), is(640));
         assertThat(video.getStreams().get(0).getFilesize(), is(4443944L));
-        assertThat(video.getStreams().get(0).getType(), is("ts"));
+        assertThat(video.getStreams().get(0).getStreamType(), is("ts"));
         assertThat(video.getStreams().get(0).getProvider(), is("elastictranscoder"));
         assertThat(video.getStreams().get(0).getBitrate(), is(600));
         assertThat(video.getStreams().get(0).getUrl(), startsWith("https://videos.posttv.com/washpost-product"));

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestVideoStream.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestVideoStream.java
@@ -33,6 +33,6 @@ public class TestVideoStream extends AbstractTest<VideoStream> {
         assertThat(videoStream.getUrl(), is("https://videos.posttv.com/washpost-production/The%20Washington%20Post/"
                 + "20150701/55944729e4b082c8417f4483/55944904e4b0ef3ccc0da042_t_1435781395718_mobile.m3u8"));
         assertThat(videoStream.getProvider(), is("elastictranscoder"));
-        assertThat(videoStream.getType(), is("ts"));
+        assertThat(videoStream.getStreamType(), is("ts"));
     }
 }

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-fixture-good.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-fixture-good.json
@@ -32,7 +32,7 @@
     "duration": 139000,
     "transcript": "This is a transcript of all the words said in the video. This can go on for quite some time.",
     "rating": "graphic",
-    "type": "clip",
+    "videoType": "clip",
     "youtubeContentId": "nKW3wvhnZoE",
     "streams": [{
             "height": 360,
@@ -40,7 +40,7 @@
             "fileSize": 4443944,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/The%20Washington%20Post/20150701/55944729e4b082c8417f4483/55944904e4b0ef3ccc0da042_t_1435781395718_mobile.m3u8",
             "bitrate": 600,
             "provider": "elastictranscoder"
@@ -50,7 +50,7 @@
             "fileSize": 2738596,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/The%20Washington%20Post/20150701/55944729e4b082c8417f4483/55944904e4b0ef3ccc0da042_t_1435781395718_mobile.m3u8",
             "bitrate": 300,
             "provider": "elastictranscoder"

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-fixture-nationals.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-fixture-nationals.json
@@ -29,7 +29,7 @@
     "videoDuration": 1198000,
     "transcript": "Lorem ipsum blah blah blah...",
     "rating": "all_ages",
-    "type": "clip",
+    "videoType": "clip",
     "youtubeContentId": "wWEwUpHvqJg",
     "streams": [{
             "height": 720,
@@ -37,7 +37,7 @@
             "fileSize": 327819354,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "mp4",
+            "streamType": "mp4",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_1413917562171-fstwsn_t_1435680963322_1280_720_2000.mp4",
             "bitrate": 2000,
             "provider": "elastictranscoder"
@@ -47,7 +47,7 @@
             "fileSize": 111252083,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "mp4",
+            "streamType": "mp4",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_1413917693028-uimk59_t_1435680963322_640_360_600.mp4",
             "bitrate": 600,
             "provider": "elastictranscoder"
@@ -57,7 +57,7 @@
             "fileSize": 75300016,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_t_1435680963733_mobile.m3u8",
             "bitrate": 300,
             "provider": "elastictranscoder"
@@ -67,7 +67,7 @@
             "fileSize": 352558468,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_t_1435680963733_master.m3u8",
             "bitrate": 2000,
             "provider": "elastictranscoder"
@@ -77,7 +77,7 @@
             "fileSize": 52552204,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_t_1435680963733_mobile.m3u8",
             "bitrate": 160,
             "provider": "elastictranscoder"
@@ -87,7 +87,7 @@
             "fileSize": 44471331,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "mp4",
+            "streamType": "mp4",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_1413918388651-bhdhw9_t_1435680963322_320_180_160.mp4",
             "bitrate": 160,
             "provider": "elastictranscoder"
@@ -97,7 +97,7 @@
             "fileSize": 838371405,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "mp4",
+            "streamType": "mp4",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_1413917648266-520npb_t_1435680963322_1920_1080_5400.mp4",
             "bitrate": 5400,
             "provider": "elastictranscoder"
@@ -107,7 +107,7 @@
             "fileSize": 124434944,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "ts",
+            "streamType": "ts",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_t_1435680963733_mobile.m3u8",
             "bitrate": 600,
             "provider": "elastictranscoder"
@@ -117,7 +117,7 @@
             "fileSize": 202124710,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "mp4",
+            "streamType": "mp4",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_1413917780312-tgh3by_t_1435680963322_854_480_1200.mp4",
             "bitrate": 1200,
             "provider": "elastictranscoder"
@@ -127,7 +127,7 @@
             "fileSize": 838371405,
             "audioCodec": null,
             "videoCodec": null,
-            "type": "smil",
+            "streamType": "smil",
             "url": "https://videos.posttv.com/washpost-production/Post%20Sports%20Live/The%20Washington%20Post/20150630/5592c09fe4b082c8417f3f72/5592c0a9e4b0ef3ccc0d9b6a_t_1435681422368.smil",
             "bitrate": 5400,
             "provider": "elastictranscoder"

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-stream-fixture-good.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/video-stream-fixture-good.json
@@ -4,7 +4,7 @@
     "fileSize": 4443944,
     "audioCodec": "mpeg-3",
     "videoCodec": "mpeg-4",
-    "type": "ts",
+    "streamType": "ts",
     "url": "https://videos.posttv.com/washpost-production/The%20Washington%20Post/20150701/55944729e4b082c8417f4483/55944904e4b0ef3ccc0da042_t_1435781395718_mobile.m3u8",
     "bitrate": 600,
     "provider": "elastictranscoder"


### PR DESCRIPTION
* Moving the type declaration string down to each concrete child of the ANS parent
* Renaming Video.type to Video.videoType
* Renaming VideoStream.type to VideoStream.streamType