### PR TITLE
Adds RawHTML schema type

### DIFF
--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/ANS.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/ANS.java
@@ -25,7 +25,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
     @Type(value = Media.class, name = Media.TYPE),
     @Type(value = Story.class, name = Story.TYPE),
     @Type(value = Text.class, name = Text.TYPE),
-    @Type(value = Video.class, name = Video.TYPE)
+    @Type(value = Video.class, name = Video.TYPE),
+    @Type(value = RawHTML.class, name = RawHTML.TYPE)
 })
 public class ANS implements TraitTyped, TraitId {
 
@@ -34,7 +35,7 @@ public class ANS implements TraitTyped, TraitId {
     // Globally unique ID
     @JsonProperty("_id")
     private String id;
-    
+
     // The runtime type of this object (see getter/setter for implementation details)
     @JsonProperty("type")
     private String type;

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/RawHTML.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/RawHTML.java
@@ -1,0 +1,75 @@
+package com.washingtonpost.arc.ans.v0_3.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * <p>Models raw_html element(s) in an ANS Content object</p>
+ */
+public class RawHTML extends ANS {
+
+    public static final String TYPE = "raw_html";
+
+    @JsonProperty("html")
+    private String html;
+
+    public RawHTML() {
+        setType(TYPE);
+    }
+    /**
+     * @return The html of the element
+     */
+    public String getHTML() {
+        return html;
+    }
+
+    /**
+     * @param html The html of the element
+     */
+    public void setHTML(String html) {
+        this.html = html;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(html)
+                .appendSuper(super.hashCode())
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        boolean result = false;
+
+        if (other instanceof RawHTML) {
+            RawHTML that = (RawHTML) other;
+            result = that.canEqual(this)
+                    && new EqualsBuilder()
+                    .append(html, that.html)
+                    .appendSuper(super.equals(other))
+                    .isEquals();
+        }
+        return result;
+    }
+
+    /**
+     * See http://www.artima.com/lejava/articles/equality.html for why we're doing this (it's essentially required at all levels
+     * of a heirarchy to make the .equals() reflexivity property work.
+     *
+     * @param other The object we're being compared against
+     * @return true, if it's an instanceof this class type
+     */
+    @Override
+    public boolean canEqual(Object other) {
+        return (other instanceof RawHTML);
+    }
+
+}

--- a/src/main/resources/schema/ans/v0_3/raw_html.json
+++ b/src/main/resources/schema/ans/v0_3/raw_html.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/v0_3/raw_html.json",
+    "description": "An html content element",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "ans.json",
+            "properties": {
+                "html": {
+                    "description": "Any arbitrary chunk of  HTML.",
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestRawHTML.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestRawHTML.java
@@ -1,0 +1,37 @@
+package com.washingtonpost.arc.ans.v0_3.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
+
+/**
+ * <p>Tests that JSON we expect to be arbitrary html serializes correctly and validates
+ * against the JSON schema</p>
+ */
+public class TestRawHTML extends AbstractANSTest<RawHTML> {
+
+    @Override
+    String getSchemaName() {
+        return "raw_html";
+    }
+
+    @Override
+    Class getTargetClass() {
+        return RawHTML.class;
+    }
+
+    @Test
+    public void testGood() throws Exception {
+        testJsonValidation("raw-html-fixture-good", true);
+        RawHTML html = testClassSerialization("raw-html-fixture-good");
+        assertThat(html.getId(), is("09876543210"));
+        assertThat(html.getType(), is("raw_html"));
+        assertThat(html.getHTML(), is("<i>Here's my html</i>"));
+    }
+
+    @Test
+    public void testBad() throws Exception {
+        testJsonValidation("text-fixture-bad", false);
+    }
+
+}

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/raw-html-fixture-bad.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/raw-html-fixture-bad.json
@@ -1,0 +1,3 @@
+{
+    "name": "vaughant"
+}

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/raw-html-fixture-good.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/raw-html-fixture-good.json
@@ -1,0 +1,5 @@
+{
+    "_id": "09876543210",
+    "type": "raw_html",
+    "html": "<i>Here's my html</i>"
+}


### PR DESCRIPTION
The vast majority of failure cases in content ingestor at this moment are "transformer-error", which makes it difficult to test for and eliminate ingestion failure cases, as well as prevents content from being ingested. To that end, getting the raw_html element in place as a fallback will probably unblock us in the medium-run 