### PR TITLE
Making the Image.height & Image.width Integer to avoid "false zeros"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
 ## 0.3.3 TBD Release Date
 
 * Adding raw_html type
+* Adding blockquote and list types
+* Making Image.height and Image.widht Integers (instead of ints) so unset JSON values will not result in deserialized "0" values
 
 ## 0.3.2 2015/10/08
 

--- a/src/main/java/com/washingtonpost/arc/ans/ANSVersion.java
+++ b/src/main/java/com/washingtonpost/arc/ans/ANSVersion.java
@@ -9,6 +9,7 @@ public enum ANSVersion {
     V0_3_0("0.3"),
     V0_3_1("0.3.1"),
     V0_3_2("0.3.2"),
+    V0_3_3("0.3.3"),
     V0_4_0("0.4");
 
     private final String versionString;

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Image.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Image.java
@@ -29,10 +29,10 @@ public class Image extends Media {
     private String url;
 
     @JsonProperty("height")
-    private int height;
+    private Integer height;
 
     @JsonProperty("width")
-    private int width;
+    private Integer width;
 
     public Image() {
         setType(TYPE);
@@ -83,7 +83,7 @@ public class Image extends Media {
     /**
      * @return Height for the image.
      */
-    public int getHeight() {
+    public Integer getHeight() {
         return height;
     }
 
@@ -91,21 +91,21 @@ public class Image extends Media {
      *
      * @param height Height for the image.
      */
-    public void setHeight(int height) {
+    public void setHeight(Integer height) {
         this.height = height;
     }
 
     /**
      * @return Width for the image.
      */
-    public int getWidth() {
+    public Integer getWidth() {
         return width;
     }
 
     /**
      * @param width Width for the image.
      */
-    public void setWidth(int width) {
+    public void setWidth(Integer width) {
         this.width = width;
     }
 

--- a/src/test/java/com/washingtonpost/arc/ans/TestANSVersion.java
+++ b/src/test/java/com/washingtonpost/arc/ans/TestANSVersion.java
@@ -16,6 +16,7 @@ public class TestANSVersion {
         assertEquals(V0_3_0, ANSVersion.fromString("0.3"));
         assertEquals(V0_3_1, ANSVersion.fromString("0.3.1"));
         assertEquals(V0_3_2, ANSVersion.fromString("0.3.2"));
+        assertEquals(V0_3_3, ANSVersion.fromString("0.3.3"));
         assertEquals(V0_4_0, ANSVersion.fromString("0.4"));
     }
 

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestImage.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestImage.java
@@ -2,6 +2,7 @@ package com.washingtonpost.arc.ans.v0_3.model;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 /**
@@ -48,4 +49,18 @@ public class TestImage extends AbstractANSTest<Image> {
         assertThat(image.getTaxonomy().getKeywords().size(), is(1));
         assertThat(image.getTaxonomy().getKeywords().get(0).getKeyword(), is("Supreme Court"));
     }
+
+    @Test
+    public void testImageStillGoodWithNoHeightOrWidth() throws Exception {
+        testJsonValidation("image-fixture-good-no-height-width", true);
+        Image image = testClassSerialization("image-fixture-good-no-height-width");
+        assertNull(image.getHeight());
+        assertNull(image.getWidth());
+
+        String jsonRepresentation = super.objectMapper.writeValueAsString(image);
+        assertThat("{\"_id\":\"unique ANS id\",\"type\":\"image\",\"version\":\"0.3.3\",\"url\":"
+                + "\"https://img.washingtonpost.com/rf/image_908w/2010-2019/WashingtonPost/2012/06/29/"
+                + "Outlook/Advance/Images/511969927-363.jpg\"}", is(jsonRepresentation));
+    }
+
 }

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/image-fixture-good-no-height-width.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/image-fixture-good-no-height-width.json
@@ -1,0 +1,6 @@
+{
+    "_id": "unique ANS id",
+    "type": "image",
+    "version": "0.3.3",
+    "url": "https://img.washingtonpost.com/rf/image_908w/2010-2019/WashingtonPost/2012/06/29/Outlook/Advance/Images/511969927-363.jpg"
+}


### PR DESCRIPTION
If we used Java "int"s for those fields then they'll show up as zeros
downstream if they are unset in the input JSON.