### PR TITLE
The spec/examples have been using Date RFC3339 formats, but the code was not

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 * Adding raw_html type
 * Adding blockquote and list types
 * Making Image.height and Image.widht Integers (instead of ints) so unset JSON values will not result in deserialized "0" values
+* Changing lastUpdatedDate and createdDate from java.util.Date to Strings of enforced RFC3339 format
 
 ## 0.3.2 2015/10/08
 

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Collection.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Collection.java
@@ -3,7 +3,6 @@ package com.washingtonpost.arc.ans.v0_3.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -44,10 +43,10 @@ public class Collection extends Content {
     private Taxonomy taxonomy;
 
     @JsonProperty("publish_date")
-    private Date publishDate;
+    private String publishDate;
 
     @JsonProperty("display_date")
-    private Date displayDate;
+    private String displayDate;
 
     @JsonProperty("content_elements")
     private List<? extends ANS> contentElements;
@@ -170,28 +169,28 @@ public class Collection extends Content {
     /**
      * @return When the story was first published.
      */
-    public Date getPublishDate() {
+    public String getPublishDate() {
         return publishDate;
     }
 
     /**
      * @param publishDate When the collection was first published.
      */
-    public void setPublishDate(Date publishDate) {
+    public void setPublishDate(String publishDate) {
         this.publishDate = publishDate;
     }
 
     /**
      * @return The RFC3339-formatted dated time of the most recent date the collection was (re)displayed on a public site.
      */
-    public Date getDisplayDate() {
+    public String getDisplayDate() {
         return displayDate;
     }
 
     /**
      * @param displayDate The RFC3339-formatted dated time of the most recent date the collection was (re)displayed on a public site.
      */
-    public void setDisplayDate(Date displayDate) {
+    public void setDisplayDate(String displayDate) {
         this.displayDate = displayDate;
     }
 

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.Date;
+import java.text.ParseException;
 import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -22,8 +22,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class Content extends ANS implements TraitDated, TraitCredited, TraitLocale, TraitLocated, TraitCopyrighted {
 
     public static final String TYPE = "content";
-    private Date createdDate;
-    private Date lastUpdatedDate;
+    private String createdDate;
+    private String lastUpdatedDate;
     private List<Credit> credits;
     private String language;
     private String location;
@@ -39,23 +39,34 @@ public class Content extends ANS implements TraitDated, TraitCredited, TraitLoca
     }
 
     @Override
-    public Date getCreatedDate() {
+    public String getCreatedDate() {
         return this.createdDate;
     }
 
     @Override
-    public void setCreatedDate(Date createdDate) {
+    public void setCreatedDate(String createdDate) {
+        validateRFC3339Date("CreatedDate", createdDate);
         this.createdDate = createdDate;
     }
 
     @Override
-    public Date getLastUpdatedDate() {
+    public String getLastUpdatedDate() {
         return this.lastUpdatedDate;
     }
 
     @Override
-    public void setLastUpdatedDate(Date lastUpdatedDate) {
+    public void setLastUpdatedDate(String lastUpdatedDate) {
+        validateRFC3339Date("LastUpdatedDate", lastUpdatedDate);
         this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    private void validateRFC3339Date(String fieldName, String dateString) {
+        try {
+            TraitDated.RFC3339.parse(dateString);
+        }
+        catch (ParseException e) {
+            throw new RuntimeException(fieldName + " '" + dateString + "' must be of RFC3339 format", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/TraitDated.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/TraitDated.java
@@ -1,9 +1,10 @@
 
 package com.washingtonpost.arc.ans.v0_3.model;
 
-import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 
 /**
@@ -14,40 +15,38 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface TraitDated {
+    public static final DateFormat RFC3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
     /**
      * When the content was originally created (RFC3339-formatted).
      * 
-     * @return
-     *     The createdDate
+     * @return The createdDate
      */
     @JsonProperty("created_date")
-    public Date getCreatedDate();
+    public String getCreatedDate();
 
     /**
      * When the content was originally created (RFC3339-formatted).
      * 
-     * @param createdDate
-     *     The created_date
+     * @param createdDate The created_date
      */
     @JsonProperty("created_date")
-    public void setCreatedDate(Date createdDate);
+    public void setCreatedDate(String createdDate);
 
     /**
      * When the content was last updated (RFC3339-formatted).
      * 
-     * @return
-     *     The lastUpdatedDate
+     * @return The lastUpdatedDate
      */
     @JsonProperty("last_updated_date")
-    public Date getLastUpdatedDate();
+    public String getLastUpdatedDate();
 
     /**
      * When the content was last updated (RFC3339-formatted).
      * 
-     * @param lastUpdatedDate
-     *     The last_updated_date
+     * @param lastUpdatedDate The last_updated_date
      */
     @JsonProperty("last_updated_date")
-    public void setLastUpdatedDate(Date lastUpdatedDate);
+    public void setLastUpdatedDate(String lastUpdatedDate);
+
 }

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTest.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTest.java
@@ -9,10 +9,6 @@ import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import java.io.IOException;
 import java.net.URL;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import static org.hamcrest.CoreMatchers.is;
@@ -32,7 +28,6 @@ import org.junit.Test;
 public abstract class AbstractTest<T> {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractTest.class);
-    private static final DateFormat RFC3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
     private final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
     private JsonSchema schema;
     protected final ObjectMapper objectMapper = new ObjectMapper();
@@ -137,15 +132,6 @@ public abstract class AbstractTest<T> {
         if (!getTargetClass().isInterface()) {
             assertThat(getTargetClass().newInstance().toString(), is(not(nullValue())));
         }
-    }
-
-    /**
-     * Assumes a date format of RFC3339 and parses the string into a date object
-     * @param date
-     * @return
-     */
-    Date date(String date) throws ParseException {
-        return RFC3339.parse(date);
     }
 
     /**

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestImage.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestImage.java
@@ -26,7 +26,7 @@ public class TestImage extends AbstractANSTest<Image> {
         testJsonValidation("image-fixture-good", true);
         Image image = testClassSerialization("image-fixture-good");
         assertThat(image.getId(), is("unique ANS id"));
-        assertThat(image.getCreatedDate(), is(date("2015-06-25T09:50:50.52Z")));
+        assertThat(image.getCreatedDate(), is("2015-06-25T09:50:50.52Z"));
         assertThat(image.getCredits().size(), is(1));
         assertThat(image.getCredits().get(0).getName(), is("Ansel Adams"));
         assertThat(image.getCredits().get(0).getRole(), is("Photographer"));

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestMedia.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestMedia.java
@@ -26,7 +26,7 @@ public class TestMedia extends AbstractANSTest<Media> {
         Media media = testClassSerialization("media-fixture-good");
         assertThat(media.getTitle(), is("Tiffany M. Ingham (Maj. Dale Greer/Kentucky Air National Guard)"));
         assertThat(media.getId(), is("unique ANS id"));
-        assertThat(media.getCreatedDate(), is(date("2015-06-25T09:50:50.52Z")));
+        assertThat(media.getCreatedDate(), is("2015-06-25T09:50:50.52Z"));
         assertThat(media.getCredits().size(), is(1));
         assertThat(media.getCredits().get(0).getName(), is("Ansel Adams"));
         assertThat(media.getCredits().get(0).getRole(), is("Photographer"));

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStory.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStory.java
@@ -30,8 +30,8 @@ public class TestStory extends AbstractANSTest<Story> {
         testJsonValidation("story-fixture-good", true);
         Story story = testClassSerialization("story-fixture-good");
         assertThat(story.getId(), is("unique ANS id"));
-        assertThat(story.getCreatedDate(), is(date("2015-06-24T09:50:50.52Z")));
-        assertThat(story.getLastUpdatedDate(), is(date("2015-06-24T09:50:50.52Z")));
+        assertThat(story.getCreatedDate(), is("2015-06-24T09:50:50.52Z"));
+        assertThat(story.getLastUpdatedDate(), is("2015-06-24T09:50:50.52Z"));
         assertThat(story.getCredits().size(), is(1));
         assertThat(story.getCredits().get(0).getName(), is("John Q. Reporter"));
         assertThat(story.getCredits().get(0).getRole(), is("Author"));
@@ -59,7 +59,7 @@ public class TestStory extends AbstractANSTest<Story> {
         assertThat(story.getPromoImages().size(), is(1));
         Image promoImage = story.getPromoImages().get(0);
         assertThat(promoImage.getId(), is("unique ANS id"));
-        assertThat(promoImage.getCreatedDate(), is(date("2015-06-25T09:50:50.52Z")));
+        assertThat(promoImage.getCreatedDate(), is("2015-06-25T09:50:50.52Z"));
         assertThat(promoImage.getCredits().get(0).getName(), is("Ansel Adams"));
         assertThat(promoImage.getCredits().get(0).getRole(), is("Photographer"));
         assertThat(promoImage.getUrl(), is("https://tinyurl.com/mqyonhb"));
@@ -70,8 +70,8 @@ public class TestStory extends AbstractANSTest<Story> {
         assertThat(story.getTaxonomy().getKeywords().get(0).getKeyword(), is("Anesthesiologist"));
         assertThat(story.getTaxonomy().getKeywords().get(0).getFrequency(), is(2));
         assertThat(story.getTaxonomy().getKeywords().get(0).getScore(), is(0.77));
-        assertThat(story.getPublishDate(), is(date("2015-06-24T09:49:00.10Z")));
-        assertThat(story.getDisplayDate(), is(date("2015-06-25T09:50:50.52Z")));
+        assertThat(story.getPublishDate(), is("2015-06-24T09:49:00.10Z"));
+        assertThat(story.getDisplayDate(), is("2015-06-25T09:50:50.52Z"));
         assertThat(story.getEditorNote(), startsWith("This URL earlier linked to a post"));
         assertThat(story.getStatus(), is("published"));
         assertThat(story.getContentElements().size(), is(6));

--- a/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/story-fixture-tiny-house.json
+++ b/src/test/resources/com/washingtonpost/arc/ans/v0_3/model/story-fixture-tiny-house.json
@@ -2,7 +2,7 @@
     "_id": "f8f706f0-0acc-11e5-9e39-0db921c47b93",
     "type": "story",
     "created_date": "2015-07-02T09:50:50.52Z",
-    "last_updated_date": "2015-07-02T09:55:00.0Z",
+    "last_updated_date": "2015-07-02T09:50:50.52Z",
     "credits": [
         {
             "name": "Nina Patel",


### PR DESCRIPTION
This corrects that and makes the native Date treatment of ANS TraitDated
objects use an RFC-3339 format String for representing Dates.