### PR TITLE
Replacing old Java date handling with newer java.time code

### DIFF
--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Collection.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Collection.java
@@ -1,8 +1,10 @@
 
 package com.washingtonpost.arc.ans.v0_3.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -173,6 +175,11 @@ public class Collection extends Content {
         return publishDate;
     }
 
+    @JsonIgnore
+    public Instant getPublishDateAsInstant() {
+        return Instant.parse(this.publishDate);
+    }
+
     /**
      * @param publishDate When the collection was first published.
      */
@@ -185,6 +192,11 @@ public class Collection extends Content {
      */
     public String getDisplayDate() {
         return displayDate;
+    }
+
+    @JsonIgnore
+    public Instant getDisplayDateAsInstant() {
+        return Instant.parse(this.displayDate);
     }
 
     /**

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/Content.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.text.ParseException;
+import java.time.Instant;
 import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -43,6 +43,11 @@ public class Content extends ANS implements TraitDated, TraitCredited, TraitLoca
         return this.createdDate;
     }
 
+    @JsonIgnore
+    public Instant getCreatedDateAsInstant() {
+        return Instant.parse(this.createdDate);
+    }
+
     @Override
     public void setCreatedDate(String createdDate) {
         validateRFC3339Date("CreatedDate", createdDate);
@@ -52,6 +57,11 @@ public class Content extends ANS implements TraitDated, TraitCredited, TraitLoca
     @Override
     public String getLastUpdatedDate() {
         return this.lastUpdatedDate;
+    }
+
+    @JsonIgnore
+    public Instant getLastUpdatedDateAsInstant() {
+        return Instant.parse(this.lastUpdatedDate);
     }
 
     @Override
@@ -64,7 +74,7 @@ public class Content extends ANS implements TraitDated, TraitCredited, TraitLoca
         try {
             TraitDated.RFC3339.parse(dateString);
         }
-        catch (ParseException e) {
+        catch (IllegalArgumentException e) {
             throw new RuntimeException(fieldName + " '" + dateString + "' must be of RFC3339 format", e);
         }
     }

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/TraitDated.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/TraitDated.java
@@ -3,9 +3,7 @@ package com.washingtonpost.arc.ans.v0_3.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-
+import java.time.format.DateTimeFormatter;
 
 /**
  * Dated trait
@@ -15,8 +13,7 @@ import java.text.SimpleDateFormat;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface TraitDated {
-    public static final DateFormat RFC3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-
+    public static final DateTimeFormatter RFC3339 = DateTimeFormatter.ISO_INSTANT;
     /**
      * When the content was originally created (RFC3339-formatted).
      * 

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/TestANSTimeHandling.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/TestANSTimeHandling.java
@@ -1,0 +1,50 @@
+package com.washingtonpost.arc.ans.v0_3;
+
+import com.washingtonpost.arc.ans.v0_3.model.Story;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * <p>Make sure the various time input/output conversions work the way we want.</p>
+ */
+public class TestANSTimeHandling {
+
+    private Story story;
+
+    @Before
+    public void onSetup() {
+        story = new Story();
+    }
+
+    @Test
+    public void testEpochSecondsToString() {
+        story.setLastUpdatedDate("1970-01-01T00:00:00Z");
+        assertEquals(Instant.EPOCH, story.getLastUpdatedDateAsInstant());
+
+        story.setCreatedDate("1970-01-01T00:00:01Z");
+        assertEquals(Instant.EPOCH.plus(1, ChronoUnit.SECONDS), story.getCreatedDateAsInstant());
+
+        story.setPublishDate("1970-01-01T00:01:00Z");
+        assertEquals(Instant.EPOCH.plus(1, ChronoUnit.MINUTES), story.getPublishDateAsInstant());
+    }
+
+    @Test
+    public void testMilliSeconds() {
+        story.setLastUpdatedDate("1970-01-01T00:00:00.123Z");
+        assertEquals(Instant.EPOCH.plus(123, ChronoUnit.MILLIS), story.getLastUpdatedDateAsInstant());
+    }
+
+    @Test(expected=DateTimeParseException.class)
+    public void testNoTrailingZ() {
+        story.setLastUpdatedDate("1970-01-01T00:00:00.123");
+    }
+
+    @Test(expected=DateTimeParseException.class)
+    public void testRequiredSeconds() {
+        story.setLastUpdatedDate("1970-01-01T00:00Z");
+    }
+}


### PR DESCRIPTION
The SimpleDateFormatter I was using in the last commit wasn't
sufficiently nimble for the different types of timestamps we're seeing
in "real" Stories.  Instead of using jodatime with its IsoDateFormatter,
I think the latest Java 8 java.time package code should be able to
support our DateFormat requirements with the Instant class.