### PR TITLE
Adding a StorySummary object; refactoring AbstractTests to be more reusable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## 0.4.0 TBD Release Date
 
+## 0.3.5 TBD Release Date
+
+* Added a StorySummary object to offer a lower-weight option for Story transmission over the wire 
+
 ## 0.3.4 2015/11/23
 
 * Added "channel" attribute to allow for per-channel variation of content elements

--- a/src/main/java/com/washingtonpost/arc/ans/v0_3/model/StorySummary.java
+++ b/src/main/java/com/washingtonpost/arc/ans/v0_3/model/StorySummary.java
@@ -1,0 +1,123 @@
+package com.washingtonpost.arc.ans.v0_3.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * <p>Digest of an ANS Story object for quicker fetching/sorting/listing</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class StorySummary {
+
+    @JsonProperty("_id")
+    private String id;
+
+    @JsonProperty("last_updated_date")
+    private String lastUpdatedDate;
+
+    @JsonProperty("canonical_url")
+    private String canonicalUrl;
+
+    @JsonProperty("headlines")
+    private List<Headline> headlines;
+
+    @JsonProperty("credits")
+    private List<Credit> credits;
+
+    public StorySummary() {
+    }
+
+    public static StorySummary fromStory(Story story) {
+        StorySummary summary = new StorySummary();
+        summary.setId(story.getId());
+        summary.setCanonicalUrl(story.getCanonicalUrl());
+        summary.setLastUpdatedDate(story.getLastUpdatedDate());
+        summary.setCredits(new ArrayList<>(story.getCredits()));
+        summary.setHeadlines(new ArrayList<>(story.getHeadlines()));
+        return summary;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLastUpdatedDate() {
+        return lastUpdatedDate;
+    }
+
+    public void setLastUpdatedDate(String lastUpdatedDate) {
+        this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    public String getCanonicalUrl() {
+        return canonicalUrl;
+    }
+
+    public void setCanonicalUrl(String canonicalUrl) {
+        this.canonicalUrl = canonicalUrl;
+    }
+
+    public List<Headline> getHeadlines() {
+        return headlines;
+    }
+
+    public void setHeadlines(List<Headline> headlines) {
+        this.headlines = headlines;
+    }
+
+    public List<Credit> getCredits() {
+        return credits;
+    }
+
+    public void setCredits(List<Credit> credits) {
+        this.credits = credits;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(this.canonicalUrl)
+                .append(this.credits)
+                .append(this.headlines)
+                .append(this.id)
+                .append(this.lastUpdatedDate)
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof StorySummary)) {
+            return false;
+        }
+        StorySummary that = ((StorySummary) other);
+        return that.canEqual(this)
+                && new EqualsBuilder()
+                .append(this.canonicalUrl, that.canonicalUrl)
+                .append(this.credits, that.credits)
+                .append(this.headlines, that.headlines)
+                .append(this.id, that.id)
+                .append(this.lastUpdatedDate, that.lastUpdatedDate)
+                .isEquals();
+    }
+
+    public boolean canEqual(Object other) {
+        return (other instanceof StorySummary);
+    }
+}

--- a/src/main/resources/schema/ans/v0_3/story-summary.json
+++ b/src/main/resources/schema/ans/v0_3/story-summary.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/v0_3/story-summary.json",
+    "description": "A summary of a story",
+    "type": "object",
+    "allOf": [{
+            "$ref": "trait_id.json",
+            "$ref": "trait_credited.json",
+            "properties": {
+                "last_updated_date": {
+                "description": "When the story was last updated (RFC3339-formatted).",
+                        "type": "string",
+                        "format": "date-time"
+                },
+                "headlines": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "headline.json"
+                    },
+                    "description": "The headline(s) for the story."
+                },
+                "canonical_url": {
+                    "type": "string",
+                    "description": "The fully qualified URL to the story."
+                }
+            }
+        }
+    ]
+}

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTest.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTest.java
@@ -1,20 +1,11 @@
 package com.washingtonpost.arc.ans.v0_3.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import java.io.IOException;
 import java.net.URL;
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.junit.Assert.fail;
@@ -25,55 +16,11 @@ import org.junit.Test;
  * <p>Helper/common methods for JSON schema/test validation</p>
  * @param <T> The type of POJO the implementing test class is stressing the JSON (de)serialization of.
  */
-public abstract class AbstractTest<T> {
+public abstract class AbstractTest<T> extends AbstractTestSupport {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractTest.class);
     private final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
     private JsonSchema schema;
-    protected final ObjectMapper objectMapper = new ObjectMapper();
-
-
-    /**
-     * @param resourcePath THe path to the resource to load
-     * @return
-     * @throws IOException
-     */
-    URL getResource(String resourcePath) throws IOException {
-        return getClass().getClassLoader().getResource(resourcePath);
-    }
-
-    /**
-     * @param fixtureName The name of the fixture in the same path as the test being executed, e.g. "credit".
-     * @return
-     * @throws IOException
-     */
-    URL getSisterPathResource(String fixtureName) throws IOException {
-        return getResource(getClass().getPackage().getName().replace(".", "/") + "/" + fixtureName + ".json");
-    }
-
-    /**
-     * @param fixtureName The name of the fixture in the same path as the test being executed, e.g. "credit".
-     * @return
-     * @throws IOException
-     */
-    JsonNode loadFixture(String fixtureName) throws IOException {
-        return JsonLoader.fromPath(getSisterPathResource(fixtureName).getFile());
-    }
-
-    /**
-     * @param schemaName The name of the schema to load, e.g. "credit".  This method assumes the schemas
-     * live under a classpath resource schema/ans/v0_X/
-     * @return
-     * @throws IOException
-     */
-    JsonNode loadSchema(String schemaName) throws IOException {
-        // Turns "com.washingtonpost.arc.ans.v0_x.model" into "schema/ans/v0_3/"
-        String schemaResourceDir = getClass().getPackage().getName()
-                .replace(".", "/")
-                .replace("com/washingtonpost/arc", "schema")
-                .replace("model", "");
-        return JsonLoader.fromPath(getResource(schemaResourceDir + schemaName + ".json").getFile());
-    }
 
     /**
      * Each test case in our subclass children will use the same schema, so there's only cause to
@@ -116,11 +63,7 @@ public abstract class AbstractTest<T> {
     @Test
     @SuppressWarnings("unchecked")
     public void testEqualsAndHashCode() {
-        if (!getTargetClass().isInterface()) {
-            EqualsVerifier.forClass(getTargetClass())
-                    .suppress(Warning.STRICT_INHERITANCE, Warning.NONFINAL_FIELDS)
-                    .verify();
-        }
+        super.testEqualsAndHashCode(getTargetClass());
     }
 
     /**
@@ -129,9 +72,7 @@ public abstract class AbstractTest<T> {
      */
     @Test
     public void testToString() throws InstantiationException, IllegalAccessException {
-        if (!getTargetClass().isInterface()) {
-            assertThat(getTargetClass().newInstance().toString(), is(not(nullValue())));
-        }
+        super.testToString(getTargetClass());
     }
 
     /**

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTestSupport.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/AbstractTestSupport.java
@@ -1,0 +1,87 @@
+package com.washingtonpost.arc.ans.v0_3.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jackson.JsonLoader;
+import java.io.IOException;
+import java.net.URL;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * <p>Static/helper methods that are used in Test classes not directly descending from Abstract*Tests</p>
+ */
+public class AbstractTestSupport {
+
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+    
+    /**
+     * @param resourcePath THe path to the resource to load
+     * @return
+     * @throws IOException
+     */
+    URL getResource(String resourcePath) throws IOException {
+        return getClass().getClassLoader().getResource(resourcePath);
+    }
+
+    /**
+     * @param fixtureName The name of the fixture in the same path as the test being executed, e.g. "credit".
+     * @return
+     * @throws IOException
+     */
+    URL getSisterPathResource(String fixtureName) throws IOException {
+        return getResource(getClass().getPackage().getName().replace(".", "/") + "/" + fixtureName + ".json");
+    }
+
+    /**
+     * @param fixtureName The name of the fixture in the same path as the test being executed, e.g. "credit".
+     * @return
+     * @throws IOException
+     */
+    JsonNode loadFixture(String fixtureName) throws IOException {
+        return JsonLoader.fromPath(getSisterPathResource(fixtureName).getFile());
+    }
+
+    /**
+     * @param schemaName The name of the schema to load, e.g. "credit".  This method assumes the schemas
+     * live under a classpath resource schema/ans/v0_X/
+     * @return
+     * @throws IOException
+     */
+    JsonNode loadSchema(String schemaName) throws IOException {
+        // Turns "com.washingtonpost.arc.ans.v0_x.model" into "schema/ans/v0_3/"
+        String schemaResourceDir = getClass().getPackage().getName()
+                .replace(".", "/")
+                .replace("com/washingtonpost/arc", "schema")
+                .replace("model", "");
+        return JsonLoader.fromPath(getResource(schemaResourceDir + schemaName + ".json").getFile());
+    }
+
+    /**
+     * @param clazz a class to test the .equals() and .hashCode method of
+     */
+    @SuppressWarnings("unchecked")
+    void testEqualsAndHashCode(Class clazz) {
+        if (!clazz.isInterface()) {
+            EqualsVerifier.forClass(clazz)
+                    .suppress(Warning.STRICT_INHERITANCE, Warning.NONFINAL_FIELDS)
+                    .verify();
+        }
+    }
+
+    /**
+     * @param clazz a class to test that its .toString() method is defined/behaves (just for code coverage reasons, really)
+     * @throws InstantiationException
+     * @throws java.lang.IllegalAccessException
+     */
+    @SuppressWarnings("unchecked")
+    public void testToString(Class clazz) throws InstantiationException, IllegalAccessException {
+        if (!clazz.isInterface()) {
+            assertThat(clazz.newInstance().toString(), is(not(nullValue())));
+        }
+    }
+}

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestAudio.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestAudio.java
@@ -43,6 +43,7 @@ public class TestAudio extends AbstractANSTest<Audio> {
         assertThat(audio.getAutoplay(), is(true));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testWithCustom() throws Exception {
         testJsonValidation("audio-fixture-good-custom", true);
@@ -51,7 +52,7 @@ public class TestAudio extends AbstractANSTest<Audio> {
         assertThat(audio.getType(), is("audio"));
         assertThat(audio.getSourceUrl(), is("https://www.washingtonpost.com/audio/foo/bar.mp3"));
         Map<String,Object> map = audio.getAdditionalProperties();
-        map = (Map<String,Object>) map.get("custom");
+        map = (Map<String, Object>) map.get("custom");
         assertThat(map.get("playerLogo"), is("https://www.washingtonpost.com/logo.png"));
     }
 

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestOembed.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestOembed.java
@@ -3,7 +3,6 @@ package com.washingtonpost.arc.ans.v0_3.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
-import java.util.Map;
 
 /**
  * <p>Tests that JSON we expect to be a valid "Paragraph" data file serializes correctly and validates

--- a/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStorySummary.java
+++ b/src/test/java/com/washingtonpost/arc/ans/v0_3/model/TestStorySummary.java
@@ -1,0 +1,37 @@
+package com.washingtonpost.arc.ans.v0_3.model;
+
+import java.io.IOException;
+import java.net.URL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * <p>Tests our StorySummary digest of the Story object</p>
+ */
+public class TestStorySummary extends AbstractTest<StorySummary> {
+
+    @Test
+    public void testSummaryConstruction() throws IOException {
+        URL url = getSisterPathResource("story-fixture-good");
+        Story story = objectMapper.readValue(url, Story.class);
+
+        StorySummary summary = StorySummary.fromStory(story);
+
+        assertEquals("unique ANS id", summary.getId());
+        assertTrue(summary.getCanonicalUrl().startsWith("http://www.washingtonpost.com/local/anesthesiologist-"));
+        assertEquals("2015-06-24T09:50:50.52Z", summary.getLastUpdatedDate());
+        assertEquals("John Q. Reporter", summary.getCredits().get(0).getName());
+        assertEquals("The default headline for this story", summary.getHeadlines().get(0).getHeadline());
+    }
+
+    @Override
+    String getSchemaName() {
+        return "story-summary";
+    }
+
+    @Override
+    Class getTargetClass() {
+        return StorySummary.class;
+    }
+}


### PR DESCRIPTION
The StorySummary is the first model object in this artifact that isn't
directly mapped to a JSON schema, so the existing patterns I had in our
AbstractTests were a little hard to re-use without a refactor of truly
generic stuff up to the AbstractTestSupport class, which I did.