### PR TITLE
Make content_element image credits match trait-credits.json

### DIFF
--- a/tests/fixtures/story-fixture-tiny-house.json
+++ b/tests/fixtures/story-fixture-tiny-house.json
@@ -106,7 +106,10 @@
       "created_date": "2015-06-25T09:50:50.52Z",
       "credits": [
         {
-          "name": "Ansel Adams",
+          "credit": {
+            "type": "author",
+            "name": "Ansel Adams"
+          },
           "role": "Photographer"
         }
       ],


### PR DESCRIPTION
The story-fixture-tiny-house.json example validates.  But there is a
credits element inside an image content_element.  It should match the
format of all other credit elements.  But since only id, type, channel
are defined for content_elements it validates.