### PR TITLE
Schema for image_operations

### DIFF
--- a/src/main/resources/schema/ans/0.5.3/image_operation.json
+++ b/src/main/resources/schema/ans/0.5.3/image_operation.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/image_operation.json",
+  "description": "An operation on an image",
+  "type": "object",
+  "allOf": [{
+    "properties": {
+      "type": {
+        "description": "Identifies this as an ANS operation",
+        "type": "string",
+        "enum": [ "image-operation" ]
+      },
+      "operation": {
+        "type": "string",
+        "description": "The identifier of the operation being performed",
+        "enum": [ "insert", "update", "delete" ]
+      },
+      "date": {
+        "description": "When the operation should be considered performed",
+        "type": "string",
+        "format": "date-time"
+      },
+      "_id": {
+        "type": "string",
+        "description": "The id of the item being operated on"
+      },
+      "organization_id": {
+        "type": "string",
+        "description": "The id of the organization"
+      },
+      "version": {
+        "type": "string",
+        "description": "The version of ANS this item is written in"
+      },
+      "body": {
+        "description": "The image being inserted/updated/deleted",
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/image.json"
+      }
+    },
+    "required": [ "type", "operation", "_id", "organization_id" ]
+  }]
+}


### PR DESCRIPTION
I tried to make this match existing operation schemas, but note `_id` for the ID of the image itself.