### PR TITLE
Licensable flag for images; channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JSON schema definition and supporting example/validation code for The Washington
 *NOTE* This schema is in development and subject to change.
 
 # Overview
-ANS ("ARC Native Specification") is the collection of schema documents that comprise the Washington Post's definition of "content", in so far as content is passed back and forth between systems in the Arc ecosystem of applications.
+ANS ("Arc Native Specification") is the collection of schema documents that comprise the Washington Post's definition of "content", in so far as content is passed back and forth between systems in the Arc ecosystem of applications.
 
 ## Schema files
 ANS Schema files are defined with the [JSON Schema specification](https://spacetelescope.github.io/understanding-json-schema/index.html).  Schemas are defined in individual files under the [src/main/resrouces/schema/ans/_version_/](src/main/resources/schema/ans/0.5.6/) directory.
@@ -69,7 +69,7 @@ ans.getValidatorForVersion('0.5.6', function(err, validator) {
 
 ## Other Commands ##
 
-##### upvert ####
+### upvert ###
 Converts a valid document in an old version of ANS to newer version.
 
 ```
@@ -103,7 +103,7 @@ npm run-script ans -- --ansdata='{"type":"story", "version":"0.5.0", "content_el
 }
 ```
 
-#### sync ####
+### sync ###
 
 Fixes an invalid document composed of valid sub-documents of differing ANS versions. Essentially this converts a very specific kind of invalid document to a valid one by selective upverting.
 
@@ -144,7 +144,7 @@ A proposal should be a short document that includes the following:
 
 ## Contributing to this Repository ##
 
-The standard method for contributing to this repository is pull requests.  For the time being, each new version requires a specific series of manual changes to the repository, listed below.
+The standard method for contributing to this repository is via pull requests.  For the time being, each new version requires a specific series of manual changes to the repository, listed below.
 
 * Branch or fork this repository.
 * Run `npm install`
@@ -155,5 +155,5 @@ The standard method for contributing to this repository is pull requests.  For t
   * Generate test fixtures for this new upverter
   * Add the new version to the internal version sequence
 * If for some reason you want to remove your new version, you can run: `npm run-script ans -- --version=x.x.x cleanup` to remove the files created by the above command.
-* Run npm test.
+* Run `npm test`.
 * Create pull request for this collection of changes.

--- a/lib/upvert/0.5.6.js
+++ b/lib/upvert/0.5.6.js
@@ -22,7 +22,7 @@ var upvert = function(input) {
         "type": "reference",
         "_id": ans._id,
         "subtype": ans.subtype,
-        "channel": ans.channels,
+        "channels": ans.channels,
         "additional_properties": ans.additional_properties,
         "referent": {
           "type": "oembed",
@@ -37,6 +37,10 @@ var upvert = function(input) {
         result[key] = value;
       } else if (key === "referent") {
         result[key] = value;
+      } else if (key === "channel") {
+        // The standard is "channels" in 0.5.7; just rename the key
+        delete result["channel"];
+        result["channels"] = value;
       } else {
         result[key] = convert(value);
       }

--- a/src/main/resources/schema/ans/0.5.7/gallery.json
+++ b/src/main/resources/schema/ans/0.5.7/gallery.json
@@ -26,6 +26,9 @@
     "copyright": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_copyright.json"
     },
+    "channels": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
+    },
     "canonical_url": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_canonical_url.json"
     },

--- a/src/main/resources/schema/ans/0.5.7/image.json
+++ b/src/main/resources/schema/ans/0.5.7/image.json
@@ -25,6 +25,9 @@
     "copyright": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_copyright.json"
     },
+    "channels": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
+    },
     "canonical_url": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_canonical_url.json"
     },

--- a/src/main/resources/schema/ans/0.5.7/image.json
+++ b/src/main/resources/schema/ans/0.5.7/image.json
@@ -137,6 +137,10 @@
     "height": {
       "description": "Height for the image.",
       "type": "integer"
+    },
+    "licensable": {
+      "description": "True if the image can legally be licensed to others.",
+      "type": "boolean"
     }
   },
   "required": [ "type", "version" ]

--- a/src/main/resources/schema/ans/0.5.7/image_operation.json
+++ b/src/main/resources/schema/ans/0.5.7/image_operation.json
@@ -21,18 +21,18 @@
         "format": "date-time"
       },
       "display_date":{
-        "description": "The RFC3339-formatted dated time of the most recent date the story was (re)displayed on a public site.",
+        "description": "The RFC3339-formatted dated time of the most recent date the image was (re)displayed on a public site.",
         "type": "string",
         "format": "date-time"
       },
       "publish_date":{
-        "description": "When the story was published.",
+        "description": "When the image was published.",
         "type": "string",
         "format": "date-time"
       },
       "_id": {
         "type": "string",
-        "description": "The id of the item being operated on"
+        "description": "The id of the image being operated on"
       },
       "organization_id": {
         "type": "string",

--- a/src/main/resources/schema/ans/0.5.7/story.json
+++ b/src/main/resources/schema/ans/0.5.7/story.json
@@ -25,6 +25,9 @@
     "copyright": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_copyright.json"
     },
+    "channels": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
+    },
     "canonical_url": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_canonical_url.json"
     },

--- a/src/main/resources/schema/ans/0.5.7/utils/content_element.json
+++ b/src/main/resources/schema/ans/0.5.7/utils/content_element.json
@@ -15,7 +15,7 @@
     "subtype": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_subtype.json"
     },
-    "channel": {
+    "channels": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
     },
     "additional_properties": {

--- a/src/main/resources/schema/ans/0.5.7/utils/reference.json
+++ b/src/main/resources/schema/ans/0.5.7/utils/reference.json
@@ -18,7 +18,7 @@
     "subtype": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_subtype.json"
     },
-    "channel": {
+    "channels": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
     },
 

--- a/src/main/resources/schema/ans/0.5.7/video.json
+++ b/src/main/resources/schema/ans/0.5.7/video.json
@@ -25,6 +25,9 @@
     "copyright": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_copyright.json"
     },
+    "channels": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_channel.json"
+    },
     "canonical_url": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.7/traits/trait_canonical_url.json"
     },

--- a/tests/fixtures/schema/0.5.7/gallery-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/gallery-fixture-good.json
@@ -5,6 +5,7 @@
     "coverPhoto" : null,
     "published" : false
   },
+  "channels": ["web"],
   "content_elements" : [ {
     "_id" : "XYZABC2",
     "additional_properties" : {

--- a/tests/fixtures/schema/0.5.7/image-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/image-fixture-good.json
@@ -2,6 +2,7 @@
   "_id": "unique ANS id",
   "type": "image",
   "version": "0.5.7",
+  "channels": ["web", "print"],
   "created_date": "2015-06-25T09:50:50.52Z",
   "credits": {
     "by": [

--- a/tests/fixtures/schema/0.5.7/image-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/image-fixture-good.json
@@ -33,6 +33,7 @@
   "subtitle": "Scalia tried to make the court a conservative stronghold. He failed.",
   "width": 800,
   "height": 640,
+  "licensable": true,
   "taxonomy": {
     "keywords": [
       {

--- a/tests/fixtures/schema/0.5.7/image-operation-create.json
+++ b/tests/fixtures/schema/0.5.7/image-operation-create.json
@@ -21,6 +21,7 @@
       } ]
     },
     "height" : 600,
+    "licensable": false,
     "subtitle" : "A test photo",
     "type" : "image",
     "url" : "http://anglerfish/fake/url/",

--- a/tests/fixtures/schema/0.5.7/image-operation-update.json
+++ b/tests/fixtures/schema/0.5.7/image-operation-update.json
@@ -21,6 +21,7 @@
       } ]
     },
     "height" : 600,
+    "licensable": true,
     "subtitle" : "A test photo",
     "type" : "image",
     "url" : "http://anglerfish/fake/url/",

--- a/tests/fixtures/schema/0.5.7/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/story-fixture-good.json
@@ -64,7 +64,7 @@
       {
         "type": "reference",
         "_id": "00001",
-        "channel": [
+        "channels": [
           "mobile"
         ],
 
@@ -259,7 +259,7 @@
     {
       "_id": "22222229",
       "type": "reference",
-      "channel": ["ios", "android"],
+      "channels": ["ios", "android"],
 
       "referent": {
         "provider": "https://api.twitter.com/1/statuses/oembed.json",

--- a/tests/fixtures/schema/0.5.7/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/story-fixture-good.json
@@ -4,6 +4,7 @@
   "version": "0.5.7",
   "created_date": "2015-06-24T09:50:50.52Z",
   "last_updated_date": "2015-06-24T09:50:50.52Z",
+  "channels": ["ios", "android"],
   "credits": {
     "by": [
       {

--- a/tests/fixtures/schema/0.5.7/video-fixture-good.json
+++ b/tests/fixtures/schema/0.5.7/video-fixture-good.json
@@ -2,6 +2,7 @@
   "_id": "unique ANS id",
   "type": "video",
   "version": "0.5.7",
+  "channels": ["ios", "android", "web", "appletv"],
   "created_date": "2015-06-25T09:50:50.52Z",
   "credits": {
     "by": [{

--- a/tests/fixtures/transforms/0.5.6/story-fixture-references-with-channel.json
+++ b/tests/fixtures/transforms/0.5.6/story-fixture-references-with-channel.json
@@ -1,0 +1,24 @@
+{
+  "_id": "unique ANS id",
+  "type": "story",
+  "version": "0.5.6",
+  "created_date": "2015-06-24T09:50:50.52Z",
+  "last_updated_date": "2015-06-24T09:50:50.52Z",
+  "language": "en",
+  "canonical_url": "http://www.washingtonpost.com/local/anesthesiologist-trashes-sedated-patient-jury-orders-her-to-pay-500000/2015/06/23/cae05c00-18f3-11e5-ab92-c75ae6ab94b5_story.html",
+  "short_url": "http://wapo.st/1Crp6bY",
+  "content_elements": [
+    {
+      "_id": "123",
+      "type": "text",
+      "channel": ["web"],
+      "content": "<h1>this is my first paragraph</h1>"
+    },
+    {
+      "_id": "456",
+      "type": "text",
+      "channel": ["post-it-note"],
+      "content": "<h2>this is my second paragraph</h2>"
+    }
+  ]
+}

--- a/tests/transform-tests.js
+++ b/tests/transform-tests.js
@@ -461,18 +461,25 @@ describe("Transformations: ", function() {
 
     describe("0.5.6 to 0.5.7", function() {
       describe("ombed", function() {
-        it("should not convert additional_properties or referent objects", function() {
+        it("should not convert additional_properties or referent objects", function () {
           var result = transforms.upvert(fixtures['0.5.6']['story-fixture-oembed'], '0.5.7');
           result.content_elements[0].additional_properties.type.should.eql("oembed");
           result.content_elements[1].referent.type.should.eql("oembed");
         });
 
-        it("should convert oembed objects to references", function() {
+        it("should convert oembed objects to references", function () {
           var result = transforms.upvert(fixtures['0.5.6']['story-fixture-oembed'], '0.5.7');
           result.content_elements[2].additional_properties.abraham.should.eql("lincoln");
           result.content_elements[2].type.should.eql("reference");
           result.content_elements[2].referent.provider.should.eql("https://api.twitter.com/1/statuses/oembed.json");
           result.content_elements[2].referent.id.should.eql("https://twitter.com/BradDavis_WFTS/status/664422935130566656");
+        });
+      });
+      describe("channels", function() {
+        it("should convert channel to channels", function() {
+          var result = transforms.upvert(fixtures['0.5.6']['story-fixture-references-with-channel'], '0.5.7');
+          result.content_elements[0].channels[0].should.eql("web");
+          result.content_elements[1].channels[0].should.eql("post-it-note");
         });
       });
     });


### PR DESCRIPTION
These five commits:

  1. Add a `licensable` flag to images from Anglerfish
  2. Add the `channels` trait to top-level stories, videos, images, and galleries
  3. Standardizes on `channels` (vs `channel` in some elements)

Tests to suit. 