### PR TITLE
Reference alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ans-schema",
   "description": "The Washington Post's Arc Native Specification",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "homepage": "https://github.com/washingtonpost/ans-schema",
   "repository": {
     "type": "git",

--- a/src/main/resources/schema/ans/0.5.8/utils/reference.json
+++ b/src/main/resources/schema/ans/0.5.8/utils/reference.json
@@ -21,6 +21,10 @@
     "channels": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_channel.json"
     },
+    "alignment": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_alignment.json"
+    },
+
 
     "referent": {
       "type": "object",

--- a/tests/fixtures/schema/0.5.8/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.8/story-fixture-good.json
@@ -327,6 +327,7 @@
       "_id": "22222229",
       "type": "reference",
       "channels": ["ios", "android"],
+      "alignment": "left",
 
       "referent": {
         "provider": "https://api.twitter.com/1/statuses/oembed.json",


### PR DESCRIPTION
`alignment` should be allowed on references

Not sure this is ever actually needed in practice (would make more sense on `referent_properties` in most real world cases?) but included here for completeness