### PR TITLE
Allow null edition_time in publication pitch event

### DIFF
--- a/src/main/resources/schema/ans/0.5.8/traits/trait_publication_pitch_event.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_publication_pitch_event.json
@@ -32,7 +32,7 @@
       "description": "The ID of the publication edition that this pitch targets."
     },
     "edition_time": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "date-time",
       "description": "The time of the publication edition that this pitch targets."
     }

--- a/tests/fixtures/schema/0.5.8/trait-publication-pitch-event-fixture-null-edition-time.json
+++ b/tests/fixtures/schema/0.5.8/trait-publication-pitch-event-fixture-null-edition-time.json
@@ -1,0 +1,3 @@
+{
+	"edition_time": null
+}

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -749,7 +749,10 @@ describe("Schema: ", function() {
           });
           it("should reject publication pitch event status containing uppercase characters", function() {
             validateIfFixtureExists(version, '/traits/trait_publication_pitch_event.json', 'trait-pitch-event-fixture-uppercase-status', false);
-          });           
+          });
+          it("should allow publication pitch events where the edition time is null", function() {
+            validateIfFixtureExists(version, '/traits/trait_publication_pitch_event.json', 'trait-publication-pitch-event-fixture-null-edition-time.json', true);
+          });
         });
 
         describe("Workflow (0.5.8+)", function() {


### PR DESCRIPTION
I wasn't able to verify that the tests pass since they appear to be broken for an unrelated reason.