### PR TITLE
Add Named Entity type

### DIFF
--- a/src/main/resources/schema/ans/0.5.8/clavis_operation.json
+++ b/src/main/resources/schema/ans/0.5.8/clavis_operation.json
@@ -47,6 +47,13 @@
         },
         "description": "A list of keywords."
       },
+      "named_entities": {
+        "type": "array",
+        "items": {
+          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/utils/named_entity.json"
+        },
+        "description": "A list of named entities."
+      },
       "topics": {
         "type": "array",
         "items": {

--- a/src/main/resources/schema/ans/0.5.8/traits/trait_taxonomy.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_taxonomy.json
@@ -13,6 +13,13 @@
       },
       "description": "A list of keywords. In the Arc ecosystem, this list is populated by Clavis."
     },
+    "named_entities": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/utils/named_entity.json"
+      },
+      "description": "A list of named entities. In the Arc ecosystem, this list is populated by Clavis."
+    },
     "topics": {
       "type": "array",
       "items": {

--- a/src/main/resources/schema/ans/0.5.8/utils/named_entity.json
+++ b/src/main/resources/schema/ans/0.5.8/utils/named_entity.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/utils/named_entity.json",
+    "title": "Named Entity",
+    "description": "Models a named entity (i.e. name of a person, place, or organization) used in a piece of content.",
+    "type": "object",
+    "required": ["_id", "name", "type"],
+    "additionalProperties": false,
+    "properties": {
+        "_id": {
+            "type": "string",
+            "description": "A unique identifier for the concept of the named entity."
+        },
+        "name": {
+            "type": "string",
+            "description": "The actual string of text that was identified as a named entity."
+        },
+        "type": {
+            "type": "string",
+            "description": "A description of what the named entity is. E.g. 'organization', 'person', or 'location'."
+        }
+    }
+}

--- a/tests/fixtures/schema/0.5.8/named-entity-fixture-bad-missing-id.json
+++ b/tests/fixtures/schema/0.5.8/named-entity-fixture-bad-missing-id.json
@@ -1,0 +1,4 @@
+{
+  "name": "JPMorgan Chase",
+  "type": "organization"
+}

--- a/tests/fixtures/schema/0.5.8/named-entity-fixture-good.json
+++ b/tests/fixtures/schema/0.5.8/named-entity-fixture-good.json
@@ -1,0 +1,5 @@
+{
+    "_id": "jpmorgan-chase",
+    "name": "JPMorgan Chase",
+    "type": "organization"
+}

--- a/tests/fixtures/schema/0.5.8/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.8/story-fixture-good.json
@@ -130,6 +130,23 @@
         "frequency": 2
       }
     ],
+    "named_entities": [
+      {
+        "_id": "jpmorgan-chase",
+        "name": "JPMorgan Chase",
+        "type": "organization"
+      },
+      {
+        "_id": "barack-obama",
+        "name": "Barack Obama",
+        "type": "person"
+      },
+      {
+        "_id": "washington-dc",
+        "name": "Washington D.C.",
+        "type": "location"
+      }
+    ],
     "primary_site": {
       "_id": "site_primary",
       "type": "site",

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -707,6 +707,16 @@ describe("Schema: ", function() {
             });
           });
 
+          describe("Named Entities", function() {
+            it("should validate a named entity", function() {
+              validateIfFixtureExists(version, '/utils/named_entity.json', 'named-entity-fixture-good');
+            });
+
+            it("should not validate a named entity without id", function() {
+              validateIfFixtureExists(version, '/utils/named_entity.json', 'named-entity-fixture-bad-missing-id', false);
+            });
+          });
+
         });
 
         describe("Label (0.5.8+)", function() {


### PR DESCRIPTION
This PR resolves #121 and adds the Named Entity type based on discussion in that Proposal. The new Named Entity type lives in `utils/` like topics and keywords. It appears in the `taxonomy` trait and the `clavis_operation` schema. 

It also adds associated tests that verify the structure of the Named Entity as well as its inclusion to the taxonomy trait.