### PR TITLE
Make comments, source, and tag objects open-ended 

### DIFF
--- a/src/main/resources/schema/ans/0.5.8/traits/trait_comments.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_comments.json
@@ -4,7 +4,7 @@
   "title": "Comments",
   "description": "Comment configuration data",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": {},
   "properties": {
     "comments_period": {
       "type": "integer",

--- a/src/main/resources/schema/ans/0.5.8/traits/trait_source.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_source.json
@@ -4,7 +4,7 @@
   "title": "Source",
   "description": "Information about the original source and/or owner of this content",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": {},
   "properties": {
     "source_id": {
       "description": "Original source CMS id",

--- a/src/main/resources/schema/ans/0.5.8/utils/tag.json
+++ b/src/main/resources/schema/ans/0.5.8/utils/tag.json
@@ -4,7 +4,7 @@
   "title": "Tag",
   "description": "Models a keyword used in describing a piece of content.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": {},
   "properties": {
     "_id": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_id.json"

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -738,10 +738,6 @@ describe("Schema: ", function() {
           it("should validate a valid source", function() {
             validateIfFixtureExists(version, '/traits/trait_source.json', 'source-good');
           });
-
-          it("should not validate an invalid source", function() {
-            validateIfFixtureExists(version, '/traits/trait_source.json', 'source-bad-extra-properties', false);
-          });
         });
 
         describe("Pitches (0.5.8+)", function() {


### PR DESCRIPTION
(fully backwards compatible with 0.5.7)