### PR TITLE
Adds proposals for chart, statistic series elements.

### DIFF
--- a/docs/proposals/2017-04-20 - Charts.md
+++ b/docs/proposals/2017-04-20 - Charts.md
@@ -1,0 +1,201 @@
+# Problem
+
+Talking to publishing support, it seems as though the most often use case for tables was when doing a "basic data chart."  Estimated usage is 1-2 times a week throughout the entire newsroom. The following are some recent examples:
+
+https://www.washingtonpost.com/lifestyle/kidspost/who-deserves-a-shot-at-the-nba-all-star-game/2017/01/25/c9995306-de5e-11e6-918c-99ede3c8cafa_story.html
+
+https://www.washingtonpost.com/news/capital-weather-gang/wp/2017/03/02/does-a-record-warm-winter-mean-a-super-hot-summer-in-d-c/
+
+Ellipsis needs to create data charts like these within an article. They need to add borders on rows or columns, a citation, and align data in cells.  Rows and columns may or may not be titled.
+
+The newsroom also uses Methode/HTML tables for other purposes via templates -- notably timelines and bar charts. These are used less often and are each tied to specific template. For Ellipsis and ANS purposes, they should be considered a separate use case. See [ANS Stat Series](2017-04-20 - Statistic Series.md).
+
+The following proposal deals specifically with the use case of creating a basic data chart.
+
+# Proposal
+
+A new `chart` format that includes row/column settings and a citation, and models cells as text elements (rather than strings.)
+
+## Title
+
+An ANS `text` element.
+
+## Citation
+
+An ANS `text` element, identical to a `citation` on the new `quote` element.  Intended to indicate the source of the data.
+
+## Credits
+
+An ANS credits object, can denormalize authors from author service. Intended to indicate the person who created this specific chart.
+
+## No width/height/sizing options
+
+Explicit sizing options are deliberately not included.
+
+## Explicitly Defined Columns - `columns`
+
+Data columns should be explicitly defined in the `columns` attribute. The following attributes can be set:
+
+* `_id` Automatically-generated.
+* `text_alignment` can be optionally set and applies to the entire column.
+* `title` text element can be optionally supplied here which can function as a header for a column.  **If at least one column has a title than a header row containing the title should be added to the chart. Otherwise it should be omitted.**
+* `borders` an array of strings with the possible values `"left"` and `"right"`
+
+## Explicitly Defined Rows - `rows`
+
+* `_id` Automatically-generated.
+* `title` text element can be optionally supplied here which can function as a header for a row.  **If at least one row has a title then a header column containing the title should be added to the chart. Otherwise it should be omitted.**
+* `borders` an array of strings with the possible values `"top"` and `"bottom"`
+* `cells` an array of cell objects.
+
+## Cells
+
+Currently these objects have just two properties:
+
+* `_id` - Automatically-generated
+* `cell_content` - currently this object can only be an ANS `text` element.
+
+# Example
+
+```
+{
+  "type": "story",
+  "version": "0.5.9",
+  "content_elements": [
+    {
+      "type": "chart",
+
+      "title": {
+        "type": "text",
+        "content": "My Awesome Chart"
+      },
+
+      "citation": {
+        "type": "text",
+        "content": "Source: The Washington Post"
+      },
+
+      "credits": {
+        "by": [{
+          "type": "author",
+          "name": "Angela Wong"
+        }]
+      },
+
+      "columns": [
+        {
+          "_id": "AAAAAAAAAAAAAAAAAAAAAA",
+          "text_alignment": "left",
+          "borders": [ "right" ],
+
+          "title": {
+            "type": "text",
+            "content": "Men"
+          }
+        },
+        {
+          "_id": "AAAAAAAAAAAAAAAAAAAAAB",
+          "text_alignment": "right",
+
+          "title": {
+            "type": "text",
+            "content": "Women"
+          }
+
+        }
+      ],
+
+
+      "rows": [
+        {
+          "_id": "AAAAAAAAAAAAAAAAC",
+          "title": {
+            "type": "text",
+            "content": "2000"
+          },
+
+          "borders": [ "bottom" ],
+
+          "cells": [
+            {
+              "_id": "AAAAAAAAAAAAAAAACA",
+              "cell_content": {
+                "type": "text",
+                "content": "$19.44"
+              }
+            },
+            {
+              "_id": "AAAAAAAAAAAAAAAACB",
+              "cell_content": {
+                "type": "text",
+                "content": "$15.22"
+              }
+            }
+          ]
+        },
+
+        {
+
+          "_id": "AAAAAAAAAAAAAAAAD",
+
+          "title": {
+            "type": "text",
+            "content": "2007"
+          },
+
+          "cells": [
+            {
+              "_id": "AAAAAAAAAAAAAAAADA",
+
+              "cell_content": {
+                "type": "text",
+                "content": "$19.45"
+              }
+            },
+            {
+              "_id": "AAAAAAAAAAAAAAAADB",
+
+              "cell_content": {
+                "type": "text",
+                "content": "$15.90"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+# Concerns
+
+### I have a bunch of legacy data with HTML tables. What should I do?
+
+You have a couple of options.
+
+* Map the data into a `chart` or other existing ANS element as best as possible. If the table you're looking at follows the same usage pattern as the `chart` element described above, this is the best choice.  If it follows mostly the same usage pattern, but requires a few new features, we can consider adding those features.
+
+* Use another ANS element for special cases, or create a new one.  For WaPo timeline/rail templates, there is the statistic series proposal.  If you have other use cases that don't map closely to any existing covered cases, we can create new element types.
+
+* Render as an image. You could take your previous table data, render it at high resolution, and save it as an image.  The preserves the presentation but loses the ability for editors to change it or renderers to reason about it.
+
+* Render as raw html.  As a second-to-last-case resort, you can simply copy the HTML into a `raw_html` element. This will work for the web but likely means the element will be omitted from apps.
+
+* Drop the element.
+
+### Why doesn't this have more formatting options?
+
+ANS Elements should be as narrowly-defined and semantic as possible. The more formatting options that are presented to the user and saved in ANS, the more constrained renderers are in their ability to present the data in an optimal way for their end-users.
+
+### Okay, but why can't I set a column width?
+
+Fixed column widths of any substance make rendering on mobile devices very difficult.  What if a mobile renderer wants to break a table up into multiple parts, or doesn't have as many pixels as the table asks for? Even percentage-based widths can result in columns that are too small to read or cause characters to bleed out. Writers and editors can't be expected to predict every possible format their content will appear in, so better to have them enter the data they want displayed with as much semantic information as possible and let designers  optimize the presentation.
+
+### I have a table doesn't make sense without a fixed column width.
+
+We can always add percentage-based widths in the future if users demand it.
+
+### What about bar graphs?
+
+We can add additional element types for graphs as demand grows.

--- a/docs/proposals/2017-04-20 - Statistic Series.md
+++ b/docs/proposals/2017-04-20 - Statistic Series.md
@@ -1,0 +1,161 @@
+# Problem
+
+Ellipsis needs to render statistics in a series with supplementary text. (This is the replacement for the timeline and rail templates in Methode.)
+
+# Proposal
+
+A content element dedicated to displaying a single set of related statistics in a series.  Each statistic can be labelled and described, and laid out in a horizontal or vertical manner.
+
+# Example
+
+
+https://www.washingtonpost.com/sports/nationals/ryan-zimmerman-returns-as-nationals-top-marlins-for-90th-win-3-2/2014/09/20/ff3a05b8-40ff-11e4-9587-5dafd96295f0_story.html?utm_term=.bc80951132c7
+
+```
+{
+  "_id": "AAAAAAAAAAABCDEFGH",
+  "type": "statistic_series",
+
+  "direction": "vertical",
+
+  "citation": {
+    "type": "text",
+    "content": "Source: The Washington Post"
+  },
+
+  "items":
+  [
+    {
+      "label": {
+        "type": "text",
+        "content": "Up to July 31"
+      },
+      "statistic": {
+        "type": "text",
+        "content": "64-41"
+      },
+      "description": {
+        "type":"text",
+        "content": "Cespedes Trade"
+      },
+      "detail": {
+        "type": "text",
+        "content": "Oakland’s record on the day the Athletics swapped slugger Yoenis Cespedes for pitcher Jon Lester. The A’s were a game ahead o f the Angels in the AL West"
+      }
+    },
+    {
+      "label": {
+        "type": "text",
+        "content": "After July 31",
+      },
+      "statistic": {
+        "type": "text",
+        "content": "18-28"
+      },
+      "description": {
+        "type":"text",
+        "content": "A's is for awful"
+      },
+      "detail": {
+        "type": "text",
+        "content": "Oakland’s record from Aug. 1 through Friday, after which the Athletics trailed the Angels by 10.5 games"
+      },
+      {
+      "label": {
+        "type": "text",
+        "content": "Oakland's Ops",
+      },
+      "statistic": {
+        "type": "text",
+        "content": ".615"
+      },
+      "description": {
+        "type":"text",
+        "content": "Bats in a slump"
+      },
+      "detail": {
+        "type": "text",
+        "content": "Oakland’s OPS over the past 30 days, the lowest in the American League"
+      },
+    {
+      "label": {
+        "type": "text",
+        "content": "Derek Jeter Ops",
+      },
+      "statistic": {
+        "type": "text",
+        "content": ".606"
+      },
+      "description": {
+        "type":"text",
+        "content": "Final season struggle"
+      },
+      "detail": {
+        "type": "text",
+        "content": "OPS for Yankees SS Derek Jeter. Only one American League player with enough plate appearances to qualify for the batting title — Houston’s Matt Dominguez — has a lower OPS for the season"
+      }
+    ]
+}
+```
+
+# Example 2
+
+https://www.washingtonpost.com/sports/wizards/2014-nba-playoffs-wizards-lose-19-point-lead-fall-to-paul-george-and-pacers/2014/05/11/c08ec1e8-d979-11e3-bda1-9b46b2066796_story.html?utm_term=.a3ed7ec11c17
+
+```
+{
+  "_id": "AAAAAAAAAAABCDEFGH",
+  "type": "statistic_series",
+
+  "direction": "vertical",
+
+  "citation": {
+    "type": "text",
+    "content": "Source: The Washington Post"
+  },
+
+  "items":
+  [
+    {
+      "label": {
+        "type": "text",
+        "content": "First Quarter"
+      },
+
+      "statistic": {
+        "type": "text",
+        "content": "57.9"
+      },
+      "description": {
+        "type": "text",
+        "content": "11 for 19"
+      }
+    },
+    {
+      "label": {
+        "type": "text",
+        "content": "Second Quarter"
+      },
+      "statistic": {
+        "type": "text",
+        "content": "52.2"
+      },
+      "description": {
+        "type": "text",
+        "content": "12 for 23"
+      }
+    }
+  ]
+}
+
+```
+
+# Concerns
+
+## Why not a table?
+
+The use case is much more specific. All these elements share a common template in The Washington Post and almost never change.
+
+# Implementation
+
+Content API / Platform Services will implement in 0.5.9.


### PR DESCRIPTION
This pull request adds proposals for two new content element types: `charts` and `statistic_series`.  

I am not wedded to the names, but the basic reasoning for the two types is as follows:

- Wanted to model some common current newsroom usage of "tables" (here meaning Methode/HTML table support)
- Wanted to target elements as specifically as possible
- Wanted to represent the data in an implementation-agnostic way (nothing specific to HTML, Methode, WordPress, etc)
- At the same time, needs to have a clear rendering solution in HTML, native apps, Ellipsis, etc.

Examples of the types of data these two elements represent are given in their respective proposal documents, which should be considered together.

This proposal should be taken to preclude adding additional element types in the future for different use cases (e.g., bar graphs)