### PR TITLE
Reworks trait_publishing to make elasticsearch 1.5 happy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ### TBD ###
 
+### 1.3.2 2017/04/28 ##
+
+* Reworks `trait_publishing`
+
 ### 1.3.1 2017/04/24 ##
 
 * Fixes bug in 0.5.7->0.5.8 upverter where an empty string in `additional_properties.workflow.status` would cause `.planning.workflow.status_code` to be set to 0 instead of not set at all.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ans-schema",
   "description": "The Washington Post's Arc Native Specification",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "homepage": "https://github.com/washingtonpost/ans-schema",
   "repository": {
     "type": "git",

--- a/src/main/resources/schema/ans/0.5.8/traits/trait_publishing.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_publishing.json
@@ -139,22 +139,23 @@
           "format": "date-time"
         },
 
-        "edition_publish_status": {
-          "title": "Publish Status",
+        "edition_published": {
+          "title": "Publish Status (Edition)",
           "description": "If false, this edition has been deleted/unpublished.",
           "type": "boolean"
         },
 
         "edition_revision_id": {
-          "title": "Revision ID",
-          "description": "The id of the revision that this edition was created from. Omitted if unpublished.",
+          "title": "Revision ID (Edition)",
+          "description": "The id of the revision that the edition was created from. Omitted if unpublished.",
           "type": "string"
         },
+
         "additional_properties": {
           "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
         }
       },
-      "required": [ "edition_publish_status", "edition_date", "edition_name" ]
+      "required": [ "edition_published", "edition_date", "edition_name" ]
     }
   }
 }

--- a/src/main/resources/schema/ans/0.5.8/traits/trait_publishing.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_publishing.json
@@ -40,40 +40,61 @@
           "type": "array",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/story_operation.json"
+            "additionalProperties": false,
+            "properties": {
+              "operation": {
+                "enum": [ "publish_edition" ]
               },
-              {
-                "type": "object",
-                "properties": {
-                  "operation": {
-                    "enum": [ "publish_edition" ]
-                  }
-                }
+              "operation_revision_id": {
+                "title": "Revision ID (Operation)",
+                "description": "The revision id to be published.",
+                "type": "string"
+              },
+              "operation_edition": {
+                "title": "Edition Name (Operation)",
+                "description": "The name of the edition this operation will publish to.",
+                "type": "string"
+              },
+              "operation_date": {
+                "title": "Operation Date",
+                "description": "The date that this operation will be performed.",
+                "type": "string"
+              },
+              "additional_properties": {
+                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
               }
-            ]
+            }
           }
         },
         "unpublish_edition": {
           "type": "array",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/story_operation.json"
+            "additionalProperties": false,
+            "properties": {
+              "operation": {
+                "enum": [ "unpublish_edition" ]
               },
-              {
-                "properties": {
-                  "operation": {
-                    "enum": [ "unpublish_edition" ]
-                  }
-                }
+              "operation_edition": {
+                "title": "Edition Name (Operation)",
+                "description": "The name of the edition this operation will publish to.",
+                "type": "string"
+              },
+              "operation_date": {
+                "title": "Operation Date",
+                "description": "The date that this operation will be performed.",
+                "type": "string"
+              },
+              "additional_properties": {
+                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
               }
-            ]
+            }
           }
         }
       }
+    },
+    "additional_properties": {
+      "$ref" : "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
     }
   },
 
@@ -81,9 +102,10 @@
 
   "definitions": {
     "edition": {
+      "additionalProperties": false,
       "properties": {
 
-        "edition": {
+        "edition_name": {
           "title": "Edition Name",
           "description": "The machine-readable identifier of this edition. This should be the same as the key in 'editions' for the edition object.",
           "type": "string"
@@ -96,40 +118,43 @@
           "format": "date-time"
         },
 
-        "first_published_date": {
-          "title": "First Published Date",
+        "edition_first_publish_date": {
+          "title": "First Published Date (Edition)",
           "description": "The machine-generated date that this edition was created for the first time (i.e., that the content item was first published.)",
           "type": "string",
           "format": "date-time"
         },
 
-        "display_date": {
+        "edition_display_date": {
           "title": "Display Date (Edition)",
           "description": "The human-editable date that should be shown to readers as the 'date' for this content item. When viewing the story at this edition name directly, this will override whatever value is set for Display Date on the story directly. After an edition is created, subsequent updates to that edition will not change this date unless otherwise specified.",
           "type": "string",
           "format": "date-time"
         },
 
-        "publish_date": {
+        "edition_publish_date": {
           "title": "Publish Date (Edition)",
           "description": "The machine-editable date that should be shown to readers as the 'publish date' for this content item. When viewing the story at this edition name directly, this will override whatever value is set for Publish Date on the story directly. Every time an edition is updated (i.e. a story is republished) this date will also be updated unless otherwise specified.",
           "type": "string",
           "format": "date-time"
         },
 
-        "published": {
+        "edition_publish_status": {
           "title": "Publish Status",
           "description": "If false, this edition has been deleted/unpublished.",
           "type": "boolean"
         },
 
-        "revision_id": {
+        "edition_revision_id": {
           "title": "Revision ID",
           "description": "The id of the revision that this edition was created from. Omitted if unpublished.",
           "type": "string"
+        },
+        "additional_properties": {
+          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
         }
       },
-      "required": [ "published", "edition_date", "edition" ]
+      "required": [ "edition_publish_status", "edition_date", "edition_name" ]
     }
   }
 }

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_publishing.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_publishing.json
@@ -40,40 +40,61 @@
           "type": "array",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/story_operation.json"
+            "additionalProperties": false,
+            "properties": {
+              "operation": {
+                "enum": [ "publish_edition" ]
               },
-              {
-                "type": "object",
-                "properties": {
-                  "operation": {
-                    "enum": [ "publish_edition" ]
-                  }
-                }
+              "operation_revision_id": {
+                "title": "Revision ID (Operation)",
+                "description": "The revision id to be published.",
+                "type": "string"
+              },
+              "operation_edition": {
+                "title": "Edition Name (Operation)",
+                "description": "The name of the edition this operation will publish to.",
+                "type": "string"
+              },
+              "operation_date": {
+                "title": "Operation Date",
+                "description": "The date that this operation will be performed.",
+                "type": "string"
+              },
+              "additional_properties": {
+                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_additional_properties.json"
               }
-            ]
+            }
           }
         },
         "unpublish_edition": {
           "type": "array",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/story_operation.json"
+            "additionalProperties": false,
+            "properties": {
+              "operation": {
+                "enum": [ "unpublish_edition" ]
               },
-              {
-                "properties": {
-                  "operation": {
-                    "enum": [ "unpublish_edition" ]
-                  }
-                }
+              "operation_edition": {
+                "title": "Edition Name (Operation)",
+                "description": "The name of the edition this operation will publish to.",
+                "type": "string"
+              },
+              "operation_date": {
+                "title": "Operation Date",
+                "description": "The date that this operation will be performed.",
+                "type": "string"
+              },
+              "additional_properties": {
+                "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_additional_properties.json"
               }
-            ]
+            }
           }
         }
       }
+    },
+    "additional_properties": {
+      "$ref" : "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_additional_properties.json"
     }
   },
 
@@ -81,9 +102,10 @@
 
   "definitions": {
     "edition": {
+      "additionalProperties": false,
       "properties": {
 
-        "edition": {
+        "edition_name": {
           "title": "Edition Name",
           "description": "The machine-readable identifier of this edition. This should be the same as the key in 'editions' for the edition object.",
           "type": "string"
@@ -96,40 +118,45 @@
           "format": "date-time"
         },
 
-        "first_published_date": {
-          "title": "First Published Date",
+        "edition_first_publish_date": {
+          "title": "First Published Date (Edition)",
           "description": "The machine-generated date that this edition was created for the first time (i.e., that the content item was first published.)",
           "type": "string",
           "format": "date-time"
         },
 
-        "display_date": {
+        "edition_display_date": {
           "title": "Display Date (Edition)",
           "description": "The human-editable date that should be shown to readers as the 'date' for this content item. When viewing the story at this edition name directly, this will override whatever value is set for Display Date on the story directly. After an edition is created, subsequent updates to that edition will not change this date unless otherwise specified.",
           "type": "string",
           "format": "date-time"
         },
 
-        "publish_date": {
+        "edition_publish_date": {
           "title": "Publish Date (Edition)",
           "description": "The machine-editable date that should be shown to readers as the 'publish date' for this content item. When viewing the story at this edition name directly, this will override whatever value is set for Publish Date on the story directly. Every time an edition is updated (i.e. a story is republished) this date will also be updated unless otherwise specified.",
           "type": "string",
           "format": "date-time"
         },
 
-        "published": {
+        "edition_publish_status": {
           "title": "Publish Status",
           "description": "If false, this edition has been deleted/unpublished.",
           "type": "boolean"
         },
 
-        "revision_id": {
+        "edition_revision_id": {
           "title": "Revision ID",
           "description": "The id of the revision that this edition was created from. Omitted if unpublished.",
           "type": "string"
+        },
+
+        "additional_properties": {
+          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/traits/trait_additional_properties.json"
         }
+
       },
-      "required": [ "published", "edition_date", "edition" ]
+      "required": [ "edition_publish_status", "edition_date", "edition_name" ]
     }
   }
 }

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_publishing.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_publishing.json
@@ -139,7 +139,7 @@
           "format": "date-time"
         },
 
-        "edition_publish_status": {
+        "edition_published": {
           "title": "Publish Status",
           "description": "If false, this edition has been deleted/unpublished.",
           "type": "boolean"
@@ -156,7 +156,7 @@
         }
 
       },
-      "required": [ "edition_publish_status", "edition_date", "edition_name" ]
+      "required": [ "edition_published", "edition_date", "edition_name" ]
     }
   }
 }

--- a/tests/fixtures/schema/0.5.8/story-fixture-tiny-house.json
+++ b/tests/fixtures/schema/0.5.8/story-fixture-tiny-house.json
@@ -147,7 +147,7 @@
         "edition_publish_date": "2017-04-15T12:00:00Z",
         "edition_display_date": "2017-04-15T15:00:00Z",
         "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "edition_publish_status": true
+        "edition_published": true
       },
       "print": {
         "edition_name": "print",
@@ -156,7 +156,7 @@
         "edition_publish_date": "2017-04-16T15:00:00Z",
         "edition_display_date": "2017-04-16T15:00:00Z",
         "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "edition_publish_status": true
+        "edition_published": true
       }
     },
     "scheduled_operations": {

--- a/tests/fixtures/schema/0.5.8/story-fixture-tiny-house.json
+++ b/tests/fixtures/schema/0.5.8/story-fixture-tiny-house.json
@@ -141,41 +141,35 @@
     "has_published_edition": true,
     "editions": {
       "default": {
-        "edition": "default",
+        "edition_name": "default",
         "edition_date": "2017-04-15T15:00:00Z",
-        "first_published_date": "2017-04-15T12:00:00Z",
-        "publish_date": "2017-04-15T12:00:00Z",
-        "display_date": "2017-04-15T15:00:00Z",
-        "revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "published": true
+        "edition_first_publish_date": "2017-04-15T12:00:00Z",
+        "edition_publish_date": "2017-04-15T12:00:00Z",
+        "edition_display_date": "2017-04-15T15:00:00Z",
+        "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
+        "edition_publish_status": true
       },
       "print": {
-        "edition": "print",
+        "edition_name": "print",
         "edition_date": "2017-04-16T15:00:00Z",
-        "first_publish_date": "2017-04-16T15:00:00Z",
-        "publish_date": "2017-04-16T15:00:00Z",
-        "display_date": "2017-04-16T15:00:00Z",
-        "revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "published": true
+        "edition_first_publish_date": "2017-04-16T15:00:00Z",
+        "edition_publish_date": "2017-04-16T15:00:00Z",
+        "edition_display_date": "2017-04-16T15:00:00Z",
+        "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
+        "edition_publish_status": true
       }
     },
     "scheduled_operations": {
       "publish_edition": [{
-        "type": "story_operation",
-        "story_id": "f8f706f0-0acc-11e5-9e39-0db921c47b93",
         "operation": "publish_edition",
-        "date": "2017-04-20T15:00:00Z",
-        "publish_date": "2017-04-15T15:00:00Z",
-        "display_date": "2017-04-15T15:00:00Z",
-        "revision_id": "DDDP33ODLZD5LESQ3CH6MLP6IM",
-        "editions": [ "default" ]
+        "operation_date": "2017-04-20T15:00:00Z",
+        "operation_revision_id": "DDDP33ODLZD5LESQ3CH6MLP6IM",
+        "operation_edition":  "default"
       }],
       "unpublish_edition": [{
-        "type": "story_operation",
-        "story_id": "f8f706f0-0acc-11e5-9e39-0db921c47b93",
         "operation": "unpublish_edition",
-        "date": "2017-04-30T15:00:00Z",
-        "editions": [ "default" ]
+        "operation_date": "2017-04-30T15:00:00Z",
+        "operation_edition": "default"
       }]
     }
   }

--- a/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
@@ -141,42 +141,48 @@
     "has_published_edition": true,
     "editions": {
       "default": {
-        "edition": "default",
+        "edition_name": "default",
         "edition_date": "2017-04-15T15:00:00Z",
-        "first_published_date": "2017-04-15T12:00:00Z",
-        "publish_date": "2017-04-15T12:00:00Z",
-        "display_date": "2017-04-15T15:00:00Z",
-        "revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "published": true
+        "edition_first_publish_date": "2017-04-15T12:00:00Z",
+        "edition_publish_date": "2017-04-15T12:00:00Z",
+        "edition_display_date": "2017-04-15T15:00:00Z",
+        "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
+        "edition_publish_status": true,
+        "additional_properties": {
+          "foo":"bar"
+        }
       },
       "print": {
-        "edition": "print",
+        "edition_name": "print",
         "edition_date": "2017-04-16T15:00:00Z",
-        "first_publish_date": "2017-04-16T15:00:00Z",
-        "publish_date": "2017-04-16T15:00:00Z",
-        "display_date": "2017-04-16T15:00:00Z",
-        "revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "published": true
+        "edition_first_publish_date": "2017-04-16T15:00:00Z",
+        "edition_publish_date": "2017-04-16T15:00:00Z",
+        "edition_display_date": "2017-04-16T15:00:00Z",
+        "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
+        "edition_publish_status": true
       }
     },
     "scheduled_operations": {
       "publish_edition": [{
-        "type": "story_operation",
-        "story_id": "f8f706f0-0acc-11e5-9e39-0db921c47b93",
         "operation": "publish_edition",
-        "date": "2017-04-20T15:00:00Z",
-        "publish_date": "2017-04-15T15:00:00Z",
-        "display_date": "2017-04-15T15:00:00Z",
-        "revision_id": "DDDP33ODLZD5LESQ3CH6MLP6IM",
-        "editions": [ "default" ]
+        "operation_date": "2017-04-20T15:00:00Z",
+        "operation_revision_id": "DDDP33ODLZD5LESQ3CH6MLP6IM",
+        "operation_edition":  "default",
+        "additional_properties": {
+          "foo": "bar"
+        }
       }],
       "unpublish_edition": [{
-        "type": "story_operation",
-        "story_id": "f8f706f0-0acc-11e5-9e39-0db921c47b93",
         "operation": "unpublish_edition",
-        "date": "2017-04-30T15:00:00Z",
-        "editions": [ "default" ]
+        "operation_date": "2017-04-30T15:00:00Z",
+        "operation_edition": "default",
+        "additional_properties": {
+          "foo": "bar"
+        }
       }]
+    },
+    "additional_properties": {
+      "foo":"bar"
     }
   }
 }

--- a/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
@@ -147,7 +147,7 @@
         "edition_publish_date": "2017-04-15T12:00:00Z",
         "edition_display_date": "2017-04-15T15:00:00Z",
         "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "edition_publish_status": true,
+        "edition_published": true,
         "additional_properties": {
           "foo":"bar"
         }
@@ -159,7 +159,7 @@
         "edition_publish_date": "2017-04-16T15:00:00Z",
         "edition_display_date": "2017-04-16T15:00:00Z",
         "edition_revision_id": "CAIP33ODLZD5LESQ3CH6MLP6IM",
-        "edition_publish_status": true
+        "edition_published": true
       }
     },
     "scheduled_operations": {

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -900,16 +900,6 @@ describe("Schema: ", function() {
             });
           });
 
-          describe("Table 2", function() {
-            it("should validate a table 2 element", function() {
-              validateIfFixtureExists(version, type_prefix + '/table_02.json', 'table_02-fixture-good');
-            });
-
-            it("should not validate a table 1 element", function() {
-              validateIfFixtureExists(version, type_prefix + '/table_02.json', 'table-fixture-good', false);
-            });
-          });
-
           describe("Interstitial Link", function() {
             it("should validate a interstitial link", function () {
               validateIfFixtureExists(version, type_prefix + '/interstitial_link.json', 'interstitial-link-fixture-good');


### PR DESCRIPTION
As I started working on the equivalent ES index updates for trait_publishing, I realized that in 1.5 (which is the current ES version deployed for most clients) the schema we had agreed upon earlier was going to have some field collisions in certain queries that would be Not Good.  This PR largely ditches the attempts to make trait_publishing fields match the story_operation (Content Ops) type and the edition type used internally in Story API and goes for prefixed fields names instead, also adding additional_properties to both objects. 

The goal here was make sure that the queries WebSked will need will work, and also that existing queries that rely on the "published: true" query that works in 1.5 and nowhere else will not suddenly start returning false positives. 

This is somewhat bad form, as I'm effectively trying to squeeze in one non-trivial 0.5.8 change after it's gone out, but no one's using the changed fields yet so it should be ok.

See also: https://github.com/WPMedia/arc-content-api-tasks/pull/103/files