### PR TITLE
Specify URI format for all URL fields

### DIFF
--- a/src/main/resources/schema/ans/0.5.9/audio.json
+++ b/src/main/resources/schema/ans/0.5.9/audio.json
@@ -133,7 +133,8 @@
 
     "source_url": {
       "description": "The audio source file.",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "mimetype": {
       "description": "Mime type of audio source file.",

--- a/src/main/resources/schema/ans/0.5.9/image.json
+++ b/src/main/resources/schema/ans/0.5.9/image.json
@@ -141,7 +141,8 @@
     },
     "url": {
       "description": "URL for the image.",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "width": {
       "description": "Width for the image.",

--- a/src/main/resources/schema/ans/0.5.9/story_elements/interstitial_link.json
+++ b/src/main/resources/schema/ans/0.5.9/story_elements/interstitial_link.json
@@ -26,7 +26,8 @@
 
     "url": {
       "description": "The interstitial link url.",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "content": {
       "description": "The interstitial link text.",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_canonical_url.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_canonical_url.json
@@ -3,5 +3,6 @@
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_canonical_url.json",
   "title": "Canonical URL",
   "description": "The fully qualified URL to the story. In the Arc ecosystem, this will be populated by the content api from the arc-canonical-url service if present.",
-  "type": "string"
+  "type": "string",
+  "format": "uri"
 }

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_label.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_label.json
@@ -17,7 +17,8 @@
         },
         "url": {
           "type": "string",
-          "description": "An optional destination url of this label."
+          "description": "An optional destination url of this label.",
+          "format": "uri"
         },
         "display": {
           "type": "boolean",
@@ -42,7 +43,8 @@
         },
         "url": {
           "type": "string",
-          "description": "An optional destination url of this label."
+          "description": "An optional destination url of this label.",
+          "format": "uri"
         },
         "display": {
           "type": "boolean",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_short_url.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_short_url.json
@@ -3,5 +3,6 @@
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_short_url.json",
   "title": "Short_Url",
   "description": "A url-shortened version of the canonical url.",
-  "type": "string"
+  "type": "string",
+  "format": "uri"
 }

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_social.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_social.json
@@ -11,7 +11,8 @@
         "type": "string"
       },
       "url": {
-        "type": "string"
+        "type": "string",
+        "format": "uri"
       }
     },
     "additionalProperties": {}

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_source.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_source.json
@@ -24,7 +24,8 @@
     },
     "edit_url": {
       "type": "string",
-      "description": "A link to edit this content in its source CMS."
+      "description": "A link to edit this content in its source CMS.",
+      "format": "uri"
     },
 
     "additional_properties": {

--- a/src/main/resources/schema/ans/0.5.9/url_operation.json
+++ b/src/main/resources/schema/ans/0.5.9/url_operation.json
@@ -39,11 +39,13 @@
       },
       "original_url": {
         "type": "string",
-        "description": "The original url that will trigger a redirect to the destination_url."
+        "description": "The original url that will trigger a redirect to the destination_url.",
+        "format": "uri"
       },
       "destination_url": {
         "type": "string",
-        "description": "The new canonical_url of the story.  The original_url will redirect to the destination_url."
+        "description": "The new canonical_url of the story.  The original_url will redirect to the destination_url.",
+        "format": "uri"
       }
     },
     "required": [ "type", "operation", "id", "organization_id" ]

--- a/src/main/resources/schema/ans/0.5.9/utils/author.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/author.json
@@ -31,7 +31,8 @@
     },
     "url": {
       "description": "A url to some deeper set of information about the contributor.",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "social_links": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_social.json"

--- a/src/main/resources/schema/ans/0.5.9/utils/oembed_response.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/oembed_response.json
@@ -36,7 +36,8 @@
         },
         "provider": {
           "description": "A URL that can resolve the id into an ANS element",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [ "provider", "id" ]

--- a/src/main/resources/schema/ans/0.5.9/utils/reference.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/reference.json
@@ -44,7 +44,8 @@
         },
         "provider": {
           "description": "A URL that can resolve the id into an ANS element",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "referent_properties": {
           "additionalProperties": {},

--- a/src/main/resources/schema/ans/0.5.9/utils/site.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/site.json
@@ -28,7 +28,8 @@
     },
     "path": {
       "description": "The url path to this site",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "parent_id": {
       "description": "The id of this section's parent site, if any",

--- a/src/main/resources/schema/ans/0.5.9/utils/video_stream.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/video_stream.json
@@ -31,7 +31,8 @@
     },
     "url": {
       "description": "Where to get the stream from.",
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "bitrate": {
       "description": "The bitrate of the video",

--- a/src/main/resources/schema/ans/0.5.9/utils/video_subtitle.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/video_subtitle.json
@@ -26,7 +26,8 @@
         },
         "url" :{
           "type": "string",
-          "description": "The url of the subtitle stream."
+          "description": "The url of the subtitle stream.",
+          "format": "uri"
         }
       }
     }

--- a/tests/fixtures/schema/0.5.9/story-fixture-references.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-references.json
@@ -61,7 +61,7 @@
           "id": "1",
           "type": "image",
           "service": "",
-          "provider": ""
+          "provider": "/provider"
         }
       }
     ]
@@ -92,7 +92,7 @@
         "type": "image",
         "id": "1",
         "service": "",
-        "provider": ""
+        "provider": "https://www.provider.com"
       }
     }
   },

--- a/tests/validator.js
+++ b/tests/validator.js
@@ -156,7 +156,7 @@ describe("ANS Validator", function() {
                       "type": "reference",
                       "referent": {
                         "type": "foo",
-                        "provider": "bar",
+                        "provider": "/bar",
                         "id": "goo"
                       }
                     }]


### PR DESCRIPTION
This adds strict`uri` format validation to all URL fields, as per [RFC3986](http://tools.ietf.org/html/rfc3986).  Both absolute and relative (reference) URI will pass validation.

All tests pass.  No new tests have been added, since they would essentially be testing JSON Schema validation.

A few fixtures were updated to pass tests, though they were all for the `reference.provider` field, which will be deprecated/removed soon.