### PR TITLE
Tighten up credits object, make explicit identifiers

### DIFF
--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -7,7 +7,7 @@
   "properties": {
     "by": {
       "title": "By",
-      "description": "The primary author(s) of this content. For a story, the writer / reporter. For a photo, the photographer, etc.",
+      "description": "The primary author(s) of a story. ",
       "type": "array",
       "items": {
         "type": "object",
@@ -21,9 +21,28 @@
         ]
       }
     },
+
+    "photographer": {
+      "title": "Photos by",
+      "description": "The primary photographer(s) of an image.",
+
+      "type": "array",
+      "items": {
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
+          }
+        ]
+      }
+    },
+
     "photos_by": {
       "title": "Photos by",
-      "description": "The photographer(s) of supplementary images included in this document, especially if this document is a gallery or a story. Note that if this document is an image, the photographer(s) should appear in the 'by' slot.",
+      "description": "The photographer(s) of supplementary images included in this document, especially if this document is a gallery or a story. Note that if this document is an image, the photographer(s) should appear in the 'photographer' slot.",
       "type": "array",
       "items": {
         "type": "object",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -23,7 +23,7 @@
     },
 
     "photographer": {
-      "title": "Photos by",
+      "title": "Photographer",
       "description": "The primary photographer(s) of an image.",
 
       "type": "array",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -6,6 +6,10 @@
   "description": "A list of people and groups attributed to this content, keyed by type of contribution. In the Arc ecosystem, references in this list will be denormalized into author objects from the arc-author-service.",
   "properties": {
     "by": {
+      "title": "By",
+      "description": "The primary author(s) of this content. For a story, the writer / reporter. For a photo, the photographer, etc.",
+      "type": "array",
+      "items": {
         "type": "object",
         "anyOf": [
           {
@@ -15,17 +19,23 @@
             "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
           }
         ]
+      }
     },
     "photos_by": {
-      "type": "object",
-      "anyOf": [
-        {
-          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
-        }
-      ]
+      "title": "Photos by",
+      "description": "The photographer(s) of supplementary images included in this document, especially if this document is a gallery or a story. Note that if this document is an image, the photographer(s) should appear in the 'by' slot.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
+          }
+        ]
+      }
     }
   },
 

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -7,25 +7,7 @@
   "properties": {
     "by": {
       "title": "By",
-      "description": "The primary author(s) of a story. ",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "anyOf": [
-          {
-            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
-          }
-        ]
-      }
-    },
-
-    "photographer": {
-      "title": "Photographer",
-      "description": "The primary photographer(s) of an image.",
-
+      "description": "The primary author(s) of this document. For a story, is is the writer or reporter. For an image, it is the photographer.",
       "type": "array",
       "items": {
         "type": "object",
@@ -42,7 +24,7 @@
 
     "photos_by": {
       "title": "Photos by",
-      "description": "The photographer(s) of supplementary images included in this document, if it is a story. Note that if this document is an image, the photographer(s) should appear in the 'photographer' slot.",
+      "description": "The photographer(s) of supplementary images included in this document, if it is a story. Note that if this document is an image, the photographer(s) should appear in the 'by' slot.",
       "type": "array",
       "items": {
         "type": "object",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -4,8 +4,33 @@
   "title": "Credit trait",
   "type": "object",
   "description": "A list of people and groups attributed to this content, keyed by type of contribution. In the Arc ecosystem, references in this list will be denormalized into author objects from the arc-author-service.",
+  "properties": {
+    "by": {
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
+          }
+        ]
+    },
+    "photos_by": {
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/author.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/utils/reference.json"
+        }
+      ]
+    }
+  },
+
   "patternProperties": {
-    ".*": {
+    "^[a-zA-Z0-9_]*": {
       "type": "array",
       "items": {
         "type": "object",

--- a/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
+++ b/src/main/resources/schema/ans/0.5.9/traits/trait_credits.json
@@ -42,7 +42,7 @@
 
     "photos_by": {
       "title": "Photos by",
-      "description": "The photographer(s) of supplementary images included in this document, especially if this document is a gallery or a story. Note that if this document is an image, the photographer(s) should appear in the 'photographer' slot.",
+      "description": "The photographer(s) of supplementary images included in this document, if it is a story. Note that if this document is an image, the photographer(s) should appear in the 'photographer' slot.",
       "type": "array",
       "items": {
         "type": "object",


### PR DESCRIPTION
Move "by" and "photos_by" out of the shadow schema

Slightly restrict the name conventions of "other" relationships