### PR TITLE
Proposal for source event metadata on outgoing Content API updates

### DIFF
--- a/docs/proposals/2017-08-03_Source_Metadata_on_Content_Operations.md
+++ b/docs/proposals/2017-08-03_Source_Metadata_on_Content_Operations.md
@@ -1,0 +1,48 @@
+# Source Metadata #
+
+
+## Problem ##
+
+Downstream consumers of Content API updates are not always be interested in referent updates, or may not be equally concerned with all types of referent updates. Currently, Content API updates do not provide any metadata about what changed in a document. This puts the onus on consumers to either process every update, regardless of source, or manually track state and compare the update with the current state to determine if processing is necessary.
+
+## Proposed Solution ##
+
+Add source metadata to outgoing updates which reflects the _primary source event_ that triggered the content api operation.
+
+```
+{
+  "id" : "default_false_XYZ123",
+  "type": "insert-story",
+  "version" : "0.5.9",
+  ...
+
+  "source": {
+    "type": "image",
+    "id": "AB456",
+  }
+}
+```
+
+* *source.type* - Indicates the type of input that caused the operation. Possible values: "story", "gallery", "image", "video", "url", "site", "author" (Later, perhaps, "clavis").
+
+* *source.id* - The id of the input document, if any, that caused the operation.
+
+* *source.referent_update* - If true, this update was triggered indirectly.
+
+## Implications ##
+
+These new fields should be an optimization only. There is no new information added by these fields that could not be determined by diffing the state or consuming the source operations from the relevant primary source services.
+
+These will not be guaranteed to be present in all cases by Content API, but they will be guaranteed to be correct if present.
+
+There should be no effect for existing consumers. The fields are completely ignorable if you are already consuming and processing all updates.
+
+## Questions ##
+
+### Why not just provide a separate stream of full diffs like Dynamo/Kinesis? ###
+
+This would be desirable in some ways but would necessitate new logic from all downstream consumers to take full advantage of it. Barring additional limitations, it would also increase the potential maximum message size (already we have pushed Kafka's max message size to 10MB.)
+
+### What is the point of `source.referent_update`? Isn't it the same as `(type.indexOf(source.type) > -1 && (id.indexOf(source.id) > -1)`? ###
+
+No. Since ANS documents can include references to themselves, it is possible for an update to a single document to also trigger referent updates to that same document.

--- a/src/main/resources/schema/ans/0.5.8/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.8/content_operation.json
@@ -47,6 +47,26 @@
       "created": {
         "type": "boolean",
         "description": "Identifies this item as created or updated."
+      },
+      "source": {
+        "title": "Operation Source",
+        "description": "Metadata about the primary source update that triggered this operation. These fields can be used by downstream consumers as an efficient way of determining the relevance of an operation.",
+        "type": "object",
+        "additionalProperties": false,
+
+        "properties": {
+          "type": {
+            "title": "Source Type",
+            "description": "The type of update that was consumed in order to produce this update. If this operation is the result of a referent update, than this type may or may not match the type of document in the body. For example, suppose story A contains image B and story C. If B is updated, then an operation may be produced with source 'image' and a body of story A (with updated image metadata.) If C is updated, then an operation may be produced with source 'story' and the body of story A.",
+            "type": "string",
+            "enum": [ "story", "gallery", "image", "video", "url", "site", "author", "clavis" ]
+          },
+          "id": {
+            "title": "Source ID",
+            "description": "The id of the document whose update was consumed in order to produce this update. If this operation is the result of a referent update, than this id will not match the id of the document in the body (except the case where a document references itself.)",
+            "type": "string"
+          }
+        }
       }
     },
     "required": [ "type", "operation", "id", "organization_id" ]

--- a/src/main/resources/schema/ans/0.5.8/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.8/content_operation.json
@@ -42,7 +42,7 @@
       },
       "body": {
         "description": "The object being inserted/updated/deleted",
-        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/story.json"
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.8/content.json"
       },
       "created": {
         "type": "boolean",

--- a/src/main/resources/schema/ans/0.5.8/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.8/content_operation.json
@@ -65,6 +65,11 @@
             "title": "Source ID",
             "description": "The id of the document whose update was consumed in order to produce this update. If this operation is the result of a referent update, than this id will not match the id of the document in the body (except the case where a document references itself.)",
             "type": "string"
+          },
+          "referent_update": {
+            "title": "Referent Update",
+            "description": "If true, this update was triggered by an update to a referenced element in the document rather than the document itself.",
+            "type": "boolean"
           }
         }
       }

--- a/src/main/resources/schema/ans/0.5.9/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.9/content_operation.json
@@ -47,7 +47,28 @@
       "created": {
         "type": "boolean",
         "description": "Identifies this item as created or updated."
+      },
+      "source": {
+        "title": "Operation Source",
+        "description": "Metadata about the primary source update that triggered this operation. These fields can be used by downstream consumers as an efficient way of determining the relevance of an operation.",
+        "type": "object",
+        "additionalProperties": false,
+
+        "properties": {
+          "type": {
+            "title": "Source Type",
+            "description": "The type of update that was consumed in order to produce this update. If this operation is the result of a referent update, than this type may or may not match the type of document in the body. For example, suppose story A contains image B and story C. If B is updated, then an operation may be produced with source 'image' and a body of story A (with updated image metadata.) If C is updated, then an operation may be produced with source 'story' and the body of story A.",
+            "type": "string",
+            "enum": [ "story", "gallery", "image", "video", "url", "site", "author", "clavis" ]
+          },
+          "id": {
+            "title": "Source ID",
+            "description": "The id of the document whose update was consumed in order to produce this update. If this operation is the result of a referent update, than this id will not match the id of the document in the body (except the case where a document references itself.)",
+            "type": "string"
+          }
+        }
       }
+
     },
     "required": [ "type", "operation", "id", "organization_id" ]
   }]

--- a/src/main/resources/schema/ans/0.5.9/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.9/content_operation.json
@@ -65,6 +65,11 @@
             "title": "Source ID",
             "description": "The id of the document whose update was consumed in order to produce this update. If this operation is the result of a referent update, than this id will not match the id of the document in the body (except the case where a document references itself.)",
             "type": "string"
+          },
+          "referent_update": {
+            "title": "Referent Update",
+            "description": "If true, this update was triggered by an update to a referenced element in the document rather than the document itself.",
+            "type": "boolean"
           }
         }
       }

--- a/src/main/resources/schema/ans/0.5.9/content_operation.json
+++ b/src/main/resources/schema/ans/0.5.9/content_operation.json
@@ -42,7 +42,7 @@
       },
       "body": {
         "description": "The object being inserted/updated/deleted",
-        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/story.json"
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/content.json"
       },
       "created": {
         "type": "boolean",

--- a/tests/fixtures/schema/0.5.8/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.8/content-operation-good.json
@@ -2,6 +2,7 @@
   "id" : "default_false_XYZ123",
   "body" : {
     "_id" : "XYZ123",
+    "version": "0.5.8",
     "type" : "story",
     "content_elements": [
       {

--- a/tests/fixtures/schema/0.5.8/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.8/content-operation-good.json
@@ -1,0 +1,26 @@
+{
+  "id" : "default_false_XYZ123",
+  "body" : {
+    "_id" : "XYZ123",
+    "type" : "story",
+    "content_elements": [
+      {
+        "type": "image",
+        "_id": "AB456"
+      }
+    ]
+  },
+  "date" : "2016-04-02T12:02:00+00:00",
+  "submit_date" : "2016-04-02T12:02:01+00:00",
+  "operation" : "insert-story",
+  "organization_id" : "washpost",
+  "type" : "content-operation",
+  "published": false,
+  "created": false,
+  "branch": "default",
+  "version" : "0.5.8",
+  "source": {
+    "type": "image",
+    "id": "AB456"
+  }
+}

--- a/tests/fixtures/schema/0.5.9/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.9/content-operation-good.json
@@ -1,27 +1,12 @@
 {
   "id" : "default_false_XYZ123",
-  "body" : {
-    "_id" : "XYZ123",
-    "version": "0.5.9",
-    "type" : "story",
-    "content_elements": [
-      {
-        "type": "image",
-        "_id": "AB456"
-      }
-    ]
-  },
-  "date" : "2016-04-02T12:02:00+00:00",
-  "submit_date" : "2016-04-02T12:02:01+00:00",
-  "operation" : "insert-story",
-  "organization_id" : "washpost",
-  "type" : "content-operation",
-  "published": false,
-  "created": false,
-  "branch": "default",
+  "type": "insert-story",
   "version" : "0.5.9",
+  ...
+
   "source": {
     "type": "image",
-    "id": "AB456"
+    "id": "AB456",
+    "referent_update": true
   }
 }

--- a/tests/fixtures/schema/0.5.9/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.9/content-operation-good.json
@@ -2,6 +2,7 @@
   "id" : "default_false_XYZ123",
   "body" : {
     "_id" : "XYZ123",
+    "version": "0.5.9",
     "type" : "story",
     "content_elements": [
       {
@@ -18,7 +19,7 @@
   "published": false,
   "created": false,
   "branch": "default",
-  "version" : "0.5.8",
+  "version" : "0.5.9",
   "source": {
     "type": "image",
     "id": "AB456"

--- a/tests/fixtures/schema/0.5.9/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.9/content-operation-good.json
@@ -1,9 +1,26 @@
 {
   "id" : "default_false_XYZ123",
   "type": "insert-story",
+  "body" : {
+    "_id" : "XYZ123",
+    "version": "0.5.9",
+    "type" : "story",
+    "content_elements": [
+      {
+        "type": "image",
+        "_id": "AB456"
+      }
+    ]
+  },
+  "date" : "2016-04-02T12:02:00+00:00",
+  "submit_date" : "2016-04-02T12:02:01+00:00",
+  "operation" : "insert-story",
+  "organization_id" : "washpost",
+  "type" : "content-operation",
+  "published": false,
+  "created": false,
+  "branch": "default",
   "version" : "0.5.9",
-  ...
-
   "source": {
     "type": "image",
     "id": "AB456",

--- a/tests/fixtures/schema/0.5.9/content-operation-good.json
+++ b/tests/fixtures/schema/0.5.9/content-operation-good.json
@@ -1,0 +1,26 @@
+{
+  "id" : "default_false_XYZ123",
+  "body" : {
+    "_id" : "XYZ123",
+    "type" : "story",
+    "content_elements": [
+      {
+        "type": "image",
+        "_id": "AB456"
+      }
+    ]
+  },
+  "date" : "2016-04-02T12:02:00+00:00",
+  "submit_date" : "2016-04-02T12:02:01+00:00",
+  "operation" : "insert-story",
+  "organization_id" : "washpost",
+  "type" : "content-operation",
+  "published": false,
+  "created": false,
+  "branch": "default",
+  "version" : "0.5.8",
+  "source": {
+    "type": "image",
+    "id": "AB456"
+  }
+}

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -626,6 +626,13 @@ describe("Schema: ", function() {
           });
         });
 
+        describe("Content Operation", function() {
+          var type = "/content_operation.json";
+          it("should validate a referent update", function () {
+            validateIfFixtureExists(version, type, "content-operation-good");
+          });
+        });
+
         describe("Story Operation", function() {
           var type = "/story_operation.json";
 


### PR DESCRIPTION
Schema change for
https://arcpublishing.atlassian.net/browse/CA-108

Related to:
https://arcpublishing.atlassian.net/browse/CA-109
https://arcpublishing.atlassian.net/wiki/spaces/CAID/pages/49595454/WebSked+Duplicate+Tasks
