### PR TITLE
ANS Author Proposal

### DIFF
--- a/docs/proposals/2017-09-25_Author.md
+++ b/docs/proposals/2017-09-25_Author.md
@@ -1,0 +1,95 @@
+## Problem
+
+Author objects currently are a very small set of the fields available to configure via the Arc Author Service/API. Most of the data from Author Service is available on via
+`additional_properties`. Furthermore, the names between the fields are not consistent in the ANS document context and the author object context. The new fields being
+added via the Transparency project further compound this issue. This document aims to expand the list of ANS fields for an author object to include all currently-editable
+author fields. Ideally this object format will also be adopted by the Author API via a new API version.
+
+## Proposal
+
+Add fields to the current ANS author object
+
+```
+{
+  // Current fields
+  "type": "author",
+  "name": "Gregory Engel",   // Equivalent to byline
+
+  "image": {
+    "type": "image",
+    "url": "https://avatars0.githubusercontent.com/u/976050?v=4&s=460"
+  },
+  "url": "https://github.com/gengel",
+  "social_links": [
+    {
+      "site": "github",
+      "url": "https://github.com/gengel"
+    },
+    {
+      "site": "twitter",
+      "url": "https://twitter.com/washingtonpost"
+    }
+  ],
+  "slug": "greg-engel",
+  "additional_properties": {
+    "custom_orgname_fieldname": "Some custom data"
+    // Copy of the entire original author object
+  },
+
+  // New fields
+  "first_name": "Gregory",
+  "last_name": "Engel",
+  "middle_name": "R",
+  "suffix": "Jr.",
+  "location": "Washington, D.C.",
+  "desk": "Content API",
+  "email": "gregory.engel@washpost.com",
+  "role": "Developer",
+  "expertise": "90s adventure games, The Mary Tyler Moore Show",
+  "affilitations": "The Washington Post",
+  "languages": "English and little else",
+  "bio": "A developer with many irons in the fire.",
+  "long_bio": "I have ever had pleasure in obtaining any little anecdotes of my ancestors. You may remember the inquiries I made among the remains of my relations when you were with me in England, and the journey I undertook for that purpose. Imagining it may be equally agreeable to you to know the circumstances of my life, many of which you are yet unacquainted with, and expecting the enjoyment of a week's uninterrupted leisure in my present country retirement, I sit down to write them for you. To which I have besides some other inducements. Having emerged from the poverty and obscurity in which I was born and bred, to a state of affluence and some degree of reputation in the world, and having gone so far through life with a considerable share of felicity, the conducing means I made use of, which with the blessing of God so well succeeded, my posterity may like to know, as they may find some of them suitable to their own situations, and therefore fit to be imitated.",
+  "books": [{
+    "title": "Today I Wrote Nothing",
+    "url": "https://www.amazon.com/Today-Wrote-Nothing-Selected-Writings/dp/159020042X/ref=sr_1_1?ie=UTF8&qid=1506355964"
+  }],
+  "education": [{
+    "name": "The Cardinal Gibbons School"
+  }, {
+    "name": "Oberlin College"
+  }],
+  "awards": [{
+    "name": "Voted Most Likely to Change His Name"
+  }],
+  "contributor": false
+}
+
+```
+
+## Concerns
+
+### When will these fields be available? ##
+
+When ANS 0.5.9 is released, Author Service will start attaching the above fields to
+denormalization requests and update messages.
+
+### What is the implication for existing content?
+
+Existing documents will not receive the new fields unless the document is re-saved or
+the author data is updated in Author Service.  Clients can manually migrate all their
+author data by editing and saving every author in author service via a script (but should
+consult with Arc before doing so.)
+
+### How will this affect existing usage of Author Service?
+
+The fields in the api v1 endpoint will be remapped to the ANS fields above. A new v2 endpoint will be created that will use the new ANS Author specification and apply validation.
+
+### What happens to additional_properties?
+
+Additional properties will continue to contain the entire original author object with the old field names as currently exists.
+
+### Will these fields be searchable in Elasticsearch?
+
+No. The fields definitions will be marked in the ANS Schema documentation to indicate that they
+are not searchable.


### PR DESCRIPTION
An attempt to formalize the new transparency fields (and other author service data) in ANS in a consistent way.