### PR TITLE
Implementation of new Author object for ANS 0.5.9

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -28,7 +28,12 @@ var doUpvert = function doUpvert(ans, version_to) {
     return ans;
   }
 
-  var version_from = new Version(version.parse_version(ans.version));
+  try {
+    var version_from = new Version(version.parse_version(ans.version));
+  }
+  catch (error) {
+    throw new Error("Could not detect old ANS version.", error);
+  }
   var minor_version = version_from.major + "." + version_from.minor;
 
   // Stop recursion

--- a/lib/upvert/0.5.8.js
+++ b/lib/upvert/0.5.8.js
@@ -8,13 +8,143 @@ var version_incrementer = transform_utils.version_incrementer;
 var top_level_types = transform_utils.top_level_types;
 var accumulatorFor = transform_utils.accumulatorFor;
 
+var convertAuthor = function convertAuthor(author) {
+  var newAuthor = _.cloneDeep(author);
+
+  // Promote string fields from additional properties if missing
+  var new_string_fields = [ 'first_name', 'last_name', 'middle_name', 'suffix', 'location', 'division', 'email',
+                            'role', 'expertise', 'affiliation', 'languages', 'long_bio', 'byline' ];
+
+  _.forEach(new_string_fields, function(fieldName) {
+    if (_.has(newAuthor, fieldName) === false &&
+        _.has(author, 'additional_properties.' + fieldName) &&
+        _.isString(_.get(author, 'additional_properties.' + fieldName))) {
+      newAuthor[fieldName] = _.get(author, 'additional_properties.' + fieldName);
+    }
+  });
+
+  // Promote books from additional_properties
+  if (_.has(newAuthor, 'books') === false && (_.has(author, 'additional_properties.books'))) {
+    var newBooks = [];
+    var books = _.get(author, 'additional_properties.books');
+    if (_.isArray(books)) {
+      _.forEach(books, function(book) {
+        var newBook = {};
+
+        if (_.isString(_.get(book, 'book_title'))) {
+          newBook.book_title = _.get(book, 'book_title');
+        }
+        if (_.isString(_.get(book, 'book_url'))) {
+          newBook.book_url = _.get(book, 'book_url');
+        }
+
+        if (_.has(newBook, 'book_title')) {
+          newBooks.push(newBook);
+        }
+      });
+      if (newBooks.length > 0) {
+        newAuthor.books = newBooks;
+      }
+    }
+  }
+
+  // Promote education from additional_properties
+  if (_.has(newAuthor, 'education') === false && (_.has(author, 'additional_properties.education'))) {
+    var newSchools = [];
+    var schools = _.get(author, 'additional_properties.education');
+    if (_.isArray(schools)) {
+      _.forEach(schools, function(school) {
+        var newSchool = {};
+
+        if (_.isString(_.get(school, 'school_name'))) {
+          newSchool.school_name = _.get(school, 'school_name');
+          newSchools.push(newSchool);
+        }
+      });
+      if (newSchools.length > 0) {
+        newAuthor.education = newSchools;
+      }
+    }
+  }
+
+  // Promote awards from additional_properties
+  if (_.has(newAuthor, 'awards') === false && (_.has(author, 'additional_properties.awards'))) {
+    var newAwards = [];
+    var awards = _.get(author, 'additional_properties.awards');
+    if (_.isArray(awards)) {
+      _.forEach(awards, function(award) {
+        var newAward = {};
+
+        if (_.isString(_.get(award, 'award_name'))) {
+          newAward.award_name = _.get(award, 'award_name');
+          newAwards.push(newAward);
+        }
+      });
+      if (newAwards.length > 0) {
+        newAuthor.awards = newAwards;
+      }
+    }
+  }
+
+  // If socialLinks exists, but social_links does not, use it
+  if ((_.has(newAuthor, 'social_links') == false) && _.has(newAuthor, 'socialLinks')) {
+    newAuthor.social_links = newAuthor.socialLinks;
+  }
+
+  // Guarantee byline field
+  if (_.has(newAuthor, 'byline') == false) {
+    if (_.has(author, 'name')) {
+      newAuthor.byline = _.get(author, 'name');
+    }
+    else {
+      newAuthor.byline = '';
+    }
+  }
+
+
+
+  newAuthor.version = '0.5.9';
+
+  var valid_author_properties = [
+    '_id', 'type', 'version', 'name', 'image', 'url', 'social_links', 'slug', 'first_name',
+    'middle_name', 'last_name', 'suffix', 'byline', 'location', 'division', 'email',
+    'role', 'expertise', 'affiliation', 'languages', 'bio', 'long_bio',
+    'books', 'education', 'contributor', 'org', 'socialLinks', 'additional_properties' ];
+
+  return _.pick(newAuthor, valid_author_properties);
+};
+
+// Generic recur-and-convert down object tree
+var convert = function convert(ans) {
+  if (!_.isObject(ans)) {
+    return ans;
+  }
+
+  if (_.isArray(ans)) {
+    return _.map(ans, convert);
+  }
+
+  if (_.has(ans, 'type')) {
+    if (ans.type === 'author') {
+      return convertAuthor(ans);
+    }
+  }
+
+  return _.transform(ans, function(result, value, key, object) {
+    if (key === 'additional_properties' || key === 'referent_properties' || key === 'referent') {
+      result[key] = value;
+    }
+    else {
+      result[key] = convert(value);
+    }
+  }, accumulatorFor(ans));
+};
+
+
 var upvert = function(input) {
   var output = version_incrementer("0.5.9")(input);
 
-  // TODO: Add upvert logic here
-  // If change is non-breaking, you can leave this as-is.
-
-  return output;
+  return convert(output);
 };
 
 module.exports = upvert;

--- a/src/main/resources/schema/ans/0.5.9/utils/author.json
+++ b/src/main/resources/schema/ans/0.5.9/utils/author.json
@@ -9,43 +9,204 @@
     "_id": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_id.json"
     },
+
     "type": {
       "description": "Indicates that this is an author",
       "type": "string",
       "enum": [ "author" ]
     },
+
+    "version": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_version.json"
+    },
+
     "name": {
-      "description": "The name of contributor.",
+      "title": "Name",
+      "description": "The full human name of contributor. See also byline, first_name, last_name, middle_name, suffix.",
       "type": "string"
     },
-    "org": {
-      "description": "The name of the organization the contributor belongs to.",
-      "type": "string"
-    },
+
     "image": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/image.json"
     },
-    "bio": {
-      "description": "A description/short bio of the contributor.",
-      "type": "string"
-    },
+
     "url": {
-      "description": "A url to some deeper set of information about the contributor.",
+      "description": "A link to an author's landing page on the website, or a personal website.",
       "type": "string"
     },
+
     "social_links": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_social.json"
     },
-    "socialLinks": {
-      "description": "Deperecated. Included for backwards-compatibility.",
-      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_social.json"
-    },
+
     "slug": {
        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_slug.json"
     },
+
+    "first_name": {
+      "title": "First Name",
+      "description": "The real first name of a human author.",
+      "type": "string"
+    },
+
+    "middle_name": {
+      "title": "Middle Name",
+      "description": "The real middle name of a human author.",
+      "type": "string"
+    },
+
+    "last_name": {
+      "title": "Last Name",
+      "description": "The real last name of a human author.",
+      "type": "string"
+    },
+
+    "suffix": {
+      "title": "Suffix",
+      "description": "The real suffix of a human author.",
+      "type": "string"
+    },
+
+    "byline": {
+      "title": "Byline",
+      "description": "The public-facing name, or nom-de-plume, name of the author.",
+      "type": "string"
+    },
+
+    "location": {
+      "title": "Location",
+      "description": "The city or locality that the author resides in or is primarily associated with.",
+      "type": "string"
+    },
+
+    "division": {
+      "title": "Division",
+      "description": "The desk or group that this author normally reports to. E.g., 'Politics' or 'Sports.'",
+      "type": "string"
+    },
+
+    "email": {
+      "title": "E-mail",
+      "description": "The professional email address of this author.",
+      "type": "string",
+      "format": "email"
+    },
+
+    "role": {
+      "title": "Role",
+      "description": "The organizational role or title of this author.",
+      "type": "string"
+    },
+
+    "expertise": {
+      "title": "Expertise",
+      "description": "A comma-delimited list of subjects the author in which the author has expertise.",
+      "type": "string"
+    },
+
+    "affiliation": {
+      "title": "Affiliation",
+      "description": "The name of an organization the author is affiliated with. E.g., The Washington Post, or George Mason University.",
+      "type": "string"
+    },
+
+    "languages": {
+      "title": "Languages",
+      "description": "A description of list of languages that the author is somewhat fluent in, excluding the native language of the parent publication, and identified in the language of the parent publication. E.g., Russian, Japanese, Greek.",
+      "type": "string"
+    },
+
+    "bio": {
+      "title": "Short Biography",
+      "description": "A one or two sentence description of the author.",
+      "type": "string"
+    },
+
+    "long_bio": {
+      "title": "Long Biography",
+      "description": "The full biography of the author.",
+      "type": "string"
+    },
+
+    "books": {
+      "title": "Books",
+      "description": "A list of books written by the author.",
+      "type": "array",
+      "items": {
+        "title": "Book",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "book_title": {
+            "title": "Title",
+            "description": "The book title.",
+            "type": "string"
+          },
+          "book_url": {
+            "title": "URL",
+            "description": "A link to a page to purchase or learn more about the book.",
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "education": {
+      "title": "Education",
+      "description": "A list of schools that this author has graduated from.",
+      "type": "array",
+      "items": {
+        "title": "School",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "school_name": {
+            "title": "School Name",
+            "description": "The name of the school.",
+            "type": "string"
+          }
+        }
+      }
+    },
+
+
+    "awards": {
+      "title": "Awards",
+      "description": "A list of awards the author has received.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "award_name": {
+            "title": "Award Name",
+            "description": "The name of the award.",
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "contributor": {
+      "type": "boolean",
+      "title": "Contributor",
+      "description": "If true, this author is an external contributor to the publication."
+    },
+
+    "org": {
+      "title": "Org",
+      "description": "Deprecated. In ANS 0.5.8 and prior versions, this field is populated with the 'location' field from Arc Author Service. New implementations should use the 'location' and 'affiliation' field. Content should be identical to 'location.'",
+      "type": "string"
+    },
+
+    "socialLinks": {
+      "description": "Deperecated. Included for backwards-compatibility. Content should be identical to social_links.",
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_social.json"
+    },
+
     "additional_properties": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_additional_properties.json"
     }
   },
-  "required": [ "type", "name" ]
+  "required": [ "type", "version", "name", "byline" ]
 }

--- a/tests/fixtures/schema/0.5.9/audio-fixture-good-streams.json
+++ b/tests/fixtures/schema/0.5.9/audio-fixture-good-streams.json
@@ -6,7 +6,9 @@
     "by": [
       {
         "type": "author",
-        "name": "John Jacob"
+        "version": "0.5.9",
+        "name": "John Jacob",
+        "byline": "John Jacob"
       }
     ]
   },

--- a/tests/fixtures/schema/0.5.9/audio-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/audio-fixture-good.json
@@ -8,7 +8,9 @@
     "by": [
       {
         "type": "author",
-        "name": "John Jacob"
+        "version": "0.5.9",
+        "name": "John Jacob",
+        "byline": "John Jacob"
       }
     ]
   },

--- a/tests/fixtures/schema/0.5.9/author-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/author-fixture-good.json
@@ -1,0 +1,80 @@
+{
+  "type": "author",
+  "version": "0.5.9",
+  "_id": "engelg",
+  "name": "Gregory Engel",
+  "image": {
+    "type": "image",
+    "version": "0.5.9",
+    "url": "https://img.washingtonpost.com/rf/image_1248x701/2010-2019/WashingtonPost/2017/11/08/Local/Images/vagovernorgop3.jpg?t=20170517a"
+  },
+  "url": "http://www.washingtonpost.com",
+  "social_links": [
+    {
+      "site": "facebook",
+      "url": "http://facebook.com/gregory.r.engel"
+    },
+    {
+      "site": "reddit",
+      "url": "http://reddit.com/u/gregory.r.engel"
+    }
+  ],
+  "slug": "gregory-r-engel",
+  "first_name": "Gregory",
+  "middle_name": "R.",
+  "last_name": "Engel",
+  "suffix": "Jr.",
+  "byline": "Greg Engel",
+  "location": "Washington, D.C.",
+  "division": "Sports",
+  "email": "gregory.engel@washpost.com",
+  "role": "Content API Developer",
+  "expertise": "Baltimore, Soviet Cinema, Blue Seashells",
+  "affiliation": "The Washington Post",
+  "languages": "Russian",
+  "bio": "Gregory Engel is a developer for Arc Publishing at The Washington Post",
+  "long_bio": "Gregory Engel is a developer for Arc Publishing at The Washington Post. He has won numerous awards for his ten-part expose on breakfast cereal marshmallows in feudal Japan, including a Very Good Writer Award from Very Good Writer Magazine. He engages in online dicourse with his numerous fans and vociferous critics. His real name is 'Joe.'",
+  "books": [
+    {
+      "book_title": "Ten Ways to Eat Ice Cream: A Human's Guide for the Intimidated",
+      "book_url": "http://icecreambook.com"
+    },
+    {
+      "book_title": "If Only They Would Build It: The History of Turtle Fences in Medieval Wisconsin",
+      "book_url": "http://turtlefencebook.com"
+    },
+    {
+      "book_title": "The Speckled Land (A George Irwin Mystery)",
+      "book_url": "http://georgeirwinmysteries.com"
+    }
+  ],
+  "education": [
+    {
+      "school_name": "Oberlin College"
+    },
+    {
+      "school_name": "International Language Institute"
+    }
+  ],
+  "awards": [
+    {
+      "award_name": "A Very Good Writer Award"
+    },
+    {
+      "award_name": "A Just-OK Writer Award"
+    }
+  ],
+  "contributor": false,
+
+  "org": "Washington, D.C.",
+  "socialLinks": [
+    {
+      "site": "facebook",
+      "url": "http://facebook.com/gregory.r.engel"
+    },
+    {
+      "site": "reddit",
+      "url": "http://reddit.com/u/gregory.r.engel"
+    }
+  ]
+}

--- a/tests/fixtures/schema/0.5.9/image-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/image-fixture-good.json
@@ -8,7 +8,9 @@
     "by": [
       {
         "name": "Ansel Adams",
-        "type": "author"
+        "byline": "John Jacob",
+        "type": "author",
+        "version": "0.5.9"
       }
     ]
   },

--- a/tests/fixtures/schema/0.5.9/image-operation-create.json
+++ b/tests/fixtures/schema/0.5.9/image-operation-create.json
@@ -17,7 +17,9 @@
     "credits" : {
       "by" : [ {
         "name" : "Johnny Anonymous",
-        "type" : "author"
+        "byline": "Johnny Anonymous",
+        "type" : "author",
+        "version": "0.5.9"
       } ]
     },
     "height" : 600,

--- a/tests/fixtures/schema/0.5.9/image-operation-update.json
+++ b/tests/fixtures/schema/0.5.9/image-operation-update.json
@@ -17,7 +17,9 @@
     "credits" : {
       "by" : [ {
         "name" : "Johnny Anonymous",
-        "type" : "author"
+        "byline": "Johnny Anonymous",
+        "type" : "author",
+        "version": "0.5.9"
       } ]
     },
     "height" : 600,

--- a/tests/fixtures/schema/0.5.9/reference-fixture-bad-addl-props.json
+++ b/tests/fixtures/schema/0.5.9/reference-fixture-bad-addl-props.json
@@ -3,6 +3,7 @@
   "foo": "bar",
   "referent": {
     "type": "author",
+    "version": "0.5.9",
     "service": "http://www.credits.com/api",
     "provider": "http://www.credits.com/api",
     "id": "00001"

--- a/tests/fixtures/schema/0.5.9/reference-fixture-bad-more-addl-props.json
+++ b/tests/fixtures/schema/0.5.9/reference-fixture-bad-more-addl-props.json
@@ -2,6 +2,7 @@
   "type": "reference",
   "referent": {
     "type": "author",
+    "version": "0.5.9",
     "service": "http://www.credits.com/api",
     "provider": "http://www.credits.com/api",
     "id": "00001",

--- a/tests/fixtures/schema/0.5.9/story-fixture-bad-corrections.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-bad-corrections.json
@@ -13,6 +13,8 @@
         "name": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "byline": "John Q. Reporter",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -78,7 +80,10 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
+
           }
         ]
       },
@@ -113,7 +118,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "credits": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-bad-extra-properties.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-bad-extra-properties.json
@@ -9,8 +9,10 @@
     "by": [
       {
         "name": "John Q. Reporter",
+        "byline": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -76,7 +78,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },
@@ -123,7 +127,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-bad-wrong-type.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-bad-wrong-type.json
@@ -8,8 +8,10 @@
     "by": [
       {
         "name": "John Q. Reporter",
+        "byline": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -75,7 +77,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },
@@ -115,7 +119,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-bad-wrong-version.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-bad-wrong-version.json
@@ -8,8 +8,10 @@
     "by": [
       {
         "name": "John Q. Reporter",
+        "byline": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -75,7 +77,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },
@@ -110,7 +114,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-good-mystery-element.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-good-mystery-element.json
@@ -8,8 +8,10 @@
     "by": [
       {
         "name": "John Q. Reporter",
+        "byline": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -75,7 +77,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-good.json
@@ -9,8 +9,10 @@
     "by": [
       {
         "name": "John Q. Reporter",
+        "byline": "John Q. Reporter",
         "org": "The Washington Post",
         "type": "author",
+        "version": "0.5.9",
         "image": {
           "_id": "unique ANS id",
           "type": "image",
@@ -96,7 +98,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },
@@ -250,7 +254,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-references.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-references.json
@@ -20,7 +20,9 @@
     "additional reporting by": [
       {
         "type": "author",
-        "name": "Greg Engel"
+        "version": "0.5.9",
+        "name": "Greg Engel",
+        "byline": "Greggo"
       }
     ]
   },
@@ -76,7 +78,9 @@
         "by": [
           {
             "name": "Ansel Adams",
-            "type": "author"
+            "byline": "Ansel Adams",
+            "type": "author",
+            "version": "0.5.9"
           }
         ]
       },
@@ -155,7 +159,9 @@
         "by": [
           {
             "type": "author",
-            "name": "Ansel Adams"
+            "version": "0.5.9",
+            "name": "Ansel Adams",
+            "byline": "Ansel Adams"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-tiny-house.json
@@ -8,8 +8,10 @@
     "by": [{
       "_id": "AUTHOR1",
       "name": "Nina Patel",
+      "byline": "Nina Patel",
       "org": "The Washington Post",
       "type": "author",
+      "version": "0.5.9",
       "slug": "nina-patel"
     }]
   },
@@ -51,7 +53,9 @@
       "credits": { "by": [
         {
           "type": "author",
-          "name": "Ansel Adams"
+          "version": "0.5.9",
+          "name": "Ansel Adams",
+          "byline": "Ansel Adams"
         }
       ]},
       "url": "https://img.washingtonpost.com/rw/2010-2019/WashingtonPost/2015/06/19/Magazine/Images/6_28%20Tinyhome2_r1.tif?uuid=fXQD2BbLEeWd3OM1NUIQDA",
@@ -108,7 +112,9 @@
         "by": [
           {
             "type": "author",
-            "name": "Ansel Adams"
+            "version": "0.5.9",
+            "name": "Ansel Adams",
+            "byline": "Ansel Adams"
           }
         ]
       },

--- a/tests/fixtures/schema/0.5.9/video-fixture-good-attached-redirect.json
+++ b/tests/fixtures/schema/0.5.9/video-fixture-good-attached-redirect.json
@@ -85,7 +85,9 @@
     "by": [
       {
         "type": "author",
-        "name": "Bruce Harris"
+        "version": "0.5.9",
+        "name": "Bruce Harris",
+        "byline": "Bruce Harris"
       }
     ]
   },

--- a/tests/fixtures/schema/0.5.9/video-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/video-fixture-good.json
@@ -7,7 +7,9 @@
   "credits": {
     "by": [{
       "name": "Bruce Harris",
-      "type": "author"
+      "byline": "Bruce Harris",
+      "type": "author",
+      "version": "0.5.9"
     }]
   },
   "location": "Washington, D.C.",

--- a/tests/fixtures/transforms/0.5.8/author-fixture.json
+++ b/tests/fixtures/transforms/0.5.8/author-fixture.json
@@ -1,0 +1,87 @@
+{
+  "type": "author",
+  "_id": "engelg",
+  "name": "Gregory Engel",
+
+  "additional_properties": {
+    "type": "author",
+    "version": "0.5.9",
+    "_id": "engelg2",
+    "name": "Gregory2 Engel",
+    "image": {
+      "type": "image",
+      "version": "0.5.9",
+      "url": "https://img.washingtonpost.com/rf/image_1248x701/2010-2019/WashingtonPost/2017/11/08/Local/Images/vagovernorgop3.jpg?t=20170517a"
+    },
+    "url": "http://www.washingtonpost.com",
+    "social_links": [
+      {
+        "site": "facebook",
+        "url": "http://facebook.com/gregory.r.engel"
+      },
+      {
+        "site": "reddit",
+        "url": "http://reddit.com/u/gregory.r.engel"
+      }
+    ],
+    "slug": "gregory-r-engel",
+    "first_name": "Gregory",
+    "middle_name": "R.",
+    "last_name": "Engel",
+    "suffix": "Jr.",
+    "byline": "Greggo",
+    "location": "Washington, D.C.",
+    "division": "Sports",
+    "email": "gregory.engel@washpost.com",
+    "role": "Content API Developer",
+    "expertise": "Baltimore, Soviet Cinema, Blue Seashells",
+    "affiliation": "The Washington Post",
+    "languages": "Russian",
+    "bio": "Gregory Engel is a developer for Arc Publishing at The Washington Post",
+    "long_bio": "Gregory Engel is a developer for Arc Publishing at The Washington Post. He has won numerous awards for his ten-part expose on breakfast cereal marshmallows in feudal Japan, including a Very Good Writer Award from Very Good Writer Magazine. He engages in online dicourse with his numerous fans and vociferous critics. His real name is 'Joe.'",
+    "books": [
+      {
+        "book_title": "Ten Ways to Eat Ice Cream: A Human's Guide for the Intimidated",
+        "book_url": "http://icecreambook.com"
+      },
+      {
+        "book_title": "If Only They Would Build It: The History of Turtle Fences in Medieval Wisconsin",
+        "book_url": "http://turtlefencebook.com"
+      },
+      {
+        "book_title": "The Speckled Land (A George Irwin Mystery)",
+        "book_url": "http://georgeirwinmysteries.com"
+      }
+    ],
+    "education": [
+      {
+        "school_name": "Oberlin College"
+      },
+      {
+        "school_name": "International Language Institute"
+      }
+    ],
+    "awards": [
+      {
+        "award_name": "A Very Good Writer Award"
+      },
+      {
+        "award_name": "A Just-OK Writer Award"
+      }
+    ],
+    "contributor": false,
+
+    "org": "Washington, D.C.",
+    "socialLinks": [
+      {
+        "site": "facebook",
+        "url": "http://facebook.com/gregory.r.engel"
+      },
+      {
+        "site": "reddit",
+        "url": "http://reddit.com/u/gregory.r.engel"
+      }
+    ],
+    "some_additional_field": "should not be copied"
+  }
+}

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -468,6 +468,12 @@ describe("Schema: ", function() {
       });
 
       describe(version, function() {
+        describe("Author (0.5.9+)", function() {
+          it("should validate a well-formatted author", function() {
+            validateIfFixtureExists('/utils/author.json', 'author-fixture-good');
+          });
+        });
+
         describe("Audio", function() {
           it("should validate a well-formatted audio", function() {
             validate(version, '/audio.json', 'audio-fixture-good');

--- a/tests/transform-tests.js
+++ b/tests/transform-tests.js
@@ -664,6 +664,23 @@ describe("Transformations: ", function() {
       });
 
     });
+
+    describe("0.5.8 to 0.5.9", function() {
+      it("should upvert an author", function() {
+        var upverter = transforms.upverters['0.5.8'];
+        var original = fixtures['0.5.8']['author-fixture'];
+        var result = upverter(original);
+        //console.log(JSON.stringify(result, 0, 2));
+        result.byline.should.eql("Greggo");
+        result.should.have.property('additional_properties');
+        result.books.should.eql(original.additional_properties.books);
+        result.education.should.eql(original.additional_properties.education);
+        result.should.not.have.property('some_additional_field');
+        result.name.should.eql("Gregory Engel");
+
+        validateAns(result, original, '0.5.9');
+      });
+    });
   });
 
   describe("Synchronizer", function() {

--- a/tests/validator.js
+++ b/tests/validator.js
@@ -178,6 +178,19 @@ describe("ANS Validator", function() {
 
 
     it("should validate items with a hyphen in their type", function() {
+      var author = {
+        "name": "BRENT SMITH",
+        "type": "author"
+      };
+
+      // Authors changed in v 0.5.9
+      var ver = new ans.version.Version(ans.version.parse_version(version));
+      var v058 = new ans.version.Version(ans.version.parse_version('0.5.8'));
+      if (ver.gt(v058)) {
+        author.version = version;
+        author.byline = "BRENT SMITH";
+      }
+
       var image_operation = {
         "_id": "1",
         "body": {
@@ -185,12 +198,7 @@ describe("ANS Validator", function() {
           "additional_properties": {         "alttext": "REUTERS"       },
           "caption": "Indiana Pacers David West celebrates during Game 6 of their NBA Eastern Conference Final playoff series against the Miami Heat in Indianapolis, Indiana June 1, 2013.",
           "credits": {
-            "photographer": [
-              {
-                "name": "BRENT SMITH",
-                "type": "author"
-              }
-            ]
+            "photographer": [ author ]
           },
           "owner": {
             "name": "REUTERS"


### PR DESCRIPTION
This is prep work for the future, and has no immediate impact on anyone until all services support ANS 0.5.9.

- Matches author fields to Google Transparency project (new Author Service fields)
- Makes `byline` distinct from `name` and is a required field
- Makes `version` required for authors