### PR TITLE
Updated source.source_type with lowercase "staff" and "wires" examples

### DIFF
--- a/src/main/resources/schema/ans/0.5.8/traits/trait_source.json
+++ b/src/main/resources/schema/ans/0.5.8/traits/trait_source.json
@@ -12,7 +12,7 @@
     },
     "source_type": {
       "type": "string",
-      "description": "The method used to enter this content. E.g. 'Staff', 'Wires'"
+      "description": "The method used to enter this content. E.g. 'staff', 'wires'"
     },
     "name": {
       "type": "string",


### PR DESCRIPTION
Filing this, as WebSked is expecting case sensitive "staff" and "wires" values for its filtering. "Staff" and "Wires" will not work.