### PR TITLE
Implements endorsement element in ANS schema CA-318

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ### TBD ###
 
 * Adds `rating` element
+* Adds `endorsement` element
 
 ### 1.3.3 2017/05/16 ##
 

--- a/src/main/resources/schema/ans/0.5.9/story_elements/endorsement.json
+++ b/src/main/resources/schema/ans/0.5.9/story_elements/endorsement.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/story_elements/endorsement.json",
+  "description": "A string indicating the item's value.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "enum": [ "endorsement" ]
+    },
+    "_id": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_id.json"
+    },
+    "subtype": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_subtype.json"
+    },
+    "channels": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_channel.json"
+    },
+    "alignment": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_alignment.json"
+    },
+
+    "additional_properties": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.9/traits/trait_additional_properties.json"
+    },
+
+    "endorsement": {
+      "description": "A string indicating the value.",
+      "type": "string"
+    }
+  },
+  "required": ["endorsement"]
+}

--- a/tests/fixtures/schema/0.5.9/endorsement-fixture-bad-missing-prop.json
+++ b/tests/fixtures/schema/0.5.9/endorsement-fixture-bad-missing-prop.json
@@ -1,0 +1,4 @@
+{
+    "_id": "ABC456789ABC",
+    "type": "endorsement"
+}

--- a/tests/fixtures/schema/0.5.9/endorsement-fixture-bad-type-mismatch.json
+++ b/tests/fixtures/schema/0.5.9/endorsement-fixture-bad-type-mismatch.json
@@ -1,0 +1,5 @@
+{
+    "_id": "ABC456789ABC",
+    "type": "endorsement",
+    "endorsement": 4.5
+}

--- a/tests/fixtures/schema/0.5.9/endorsement-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/endorsement-fixture-good.json
@@ -1,0 +1,5 @@
+{
+    "_id": "ABC456789ABC",
+    "type": "endorsement",
+    "endorsement": "Don't Buy"
+}

--- a/tests/fixtures/schema/0.5.9/story-fixture-good.json
+++ b/tests/fixtures/schema/0.5.9/story-fixture-good.json
@@ -433,6 +433,11 @@
       "min": 0,
       "max": 5,
       "units": "stars"
+    },
+    {
+      "_id": "7asd8911001fs4144sajhvt",
+      "type": "endorsement",
+      "endorsement": "Recommended"
     }
   ],
 

--- a/tests/schema-tests-05.js
+++ b/tests/schema-tests-05.js
@@ -854,6 +854,20 @@ describe("Schema: ", function() {
                validateIfFixtureExists(version, type_prefix + '/rating.json', 'rating-fixture-good-only-rating'); 
             });
           });
+            
+          describe("Endorsement", function() {
+            it("should validate a valid endorsement", function() {
+              validateIfFixtureExists(version, type_prefix + '/endorsement.json', 'endorsement-fixture-good');    
+            });
+            
+            it("should not validate an endorsement with a number value for a property that should be a string", function() {
+              validateIfFixtureExists(version, type_prefix + '/endorsement.json', 'endorsement-fixture-bad-type-mismatch', false); 
+            });
+            
+            it("should not validate an endorsement with a property missing", function() {
+              validateIfFixtureExists(version, type_prefix + '/endorsement.json', 'endorsement-fixture-bad-missing-prop', false); 
+            });
+          });
 
           describe("List", function() {
             it("should validate a list of text elements", function() {
@@ -973,7 +987,7 @@ describe("Schema: ", function() {
                 var document = fixtures[fixtureName];
 
                 document.content_elements.forEach(function(element) {
-                  element.type.should.equalOneOf([ "blockquote", "code", "interstitial_link", "list", "oembed", "oembed_response", "raw_html", "table", "text", "reference", "image", "video", "audio", "story", "element_group", "quote", "correction", "rating"]);
+                  element.type.should.equalOneOf([ "blockquote", "code", "interstitial_link", "list", "oembed", "oembed_response", "raw_html", "table", "text", "reference", "image", "video", "audio", "story", "element_group", "quote", "correction", "rating", "endorsement"]);
 
                   switch(element.type) {
                   case "correction":
@@ -1024,6 +1038,9 @@ describe("Schema: ", function() {
                     break;
                   case "rating":
                     validate(version, type_prefix + '/rating.json', element);
+                    break;
+                  case "endorsement":
+                    validate(version, type_prefix + '/endorsement.json', element);
                     break;
                   }
                 });


### PR DESCRIPTION
# What is implemented?

Adds a new 'endorsement' element to the ANS schema.

# How was it tested?

Unit tests were added for the new schema, and a test that validates an entire story was modified to include the new element. The modified test still passes with the new element added. 

# What are the side effects or dependencies?

Need to update elasticsearch mappings here: 
https://github.com/WPMedia/arc-content-api-tasks/tree/development/app/services/elasticsearch_mappings

Also need to apply those updates to each ECS cluster.

# What are the failure cases?

None that I know of. 

# What metrics were added?

n/a

# Where is the documentation?

Repo itself is documentation for ANS schema.

# Did you update RELEASE NOTES?

Yes