### PR TITLE
Add associated_tasks stanza to taxonomy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./lib/ans.js",
   "scripts": {
-    "test": "mocha tests/schema-tests-04.js tests/schema-tests-05.js tests/schema-tests-06.js tests/transform-tests tests/validator",
+    "test": "mocha tests/schema-tests-04.js tests/schema-tests-05.js tests/schema-tests-06.js tests/schema-tests-07.js tests/transform-tests tests/validator",
     "ans": "node lib/cli.js"
   },
   "bin": {

--- a/src/main/resources/schema/ans/0.7.1/traits/trait_taxonomy.json
+++ b/src/main/resources/schema/ans/0.7.1/traits/trait_taxonomy.json
@@ -170,6 +170,16 @@
       }
     },
 
+    "associated_tasks": {
+      "description": "A list of WebSked task IDs that this content was created or curated to satisfy.",
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{24}$"
+      }
+    },
+
     "additional_properties": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.7.1/traits/trait_additional_properties.json"
     }

--- a/tests/fixtures/schema/0.7.1/story-fixture-bad-taxonomy-additional-tasks.json
+++ b/tests/fixtures/schema/0.7.1/story-fixture-bad-taxonomy-additional-tasks.json
@@ -1,0 +1,105 @@
+{
+  "_id": "unique ANS id",
+  "version": "0.7.1",
+  "type": "story",
+  "created_date": "2015-06-24T09:50:50.52Z",
+  "last_updated_date": "2015-06-24T09:50:50.52Z",
+  "channels": ["ios", "android"],
+  "language": "en",
+  "taxonomy": {
+    "associated_tasks": [
+      "5b9a7ffce4b0a981ee6a9897",
+      "this is not a valid task",
+      "5b92bb3ce08ea96cb2fa8ca4"
+    ],
+    "tags": [
+      {
+        "_id": "fred",
+        "text": "Fred",
+        "slug": "fred",
+        "description": "For all things Fred",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      },
+      {
+        "_id": "writing",
+        "text": "Writing"
+      }
+    ],
+    "keywords": [
+      {
+        "keyword": "Anesthesiologist",
+        "score": 0.77,
+        "frequency": 2
+      }
+    ],
+    "named_entities": [
+      {
+        "_id": "jpmorgan-chase",
+        "name": "JPMorgan Chase",
+        "type": "organization"
+      },
+      {
+        "_id": "barack-obama",
+        "name": "Barack Obama",
+        "type": "person"
+      },
+      {
+        "_id": "washington-dc",
+        "name": "Washington D.C.",
+        "type": "location"
+      }
+    ],
+    "primary_site": {
+      "_id": "site_primary",
+      "type": "site",
+      "version": "0.7.1",
+      "name": "News",
+      "description": "General News",
+      "path": "/news",
+      "additional_properties": {
+        "baz": "bag"
+      }
+    },
+    "sites": [
+      {
+        "_id": "site_1",
+        "type": "site",
+        "version": "0.7.1",
+        "primary": false,
+        "name": "Business",
+        "description": "For all your business needs",
+        "path": "/business",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      },
+      {
+        "_id": "site_2",
+        "type": "site",
+        "version": "0.7.1",
+        "primary": true,
+        "name": "Manufacturing",
+        "description": "For all your manufacturing needs",
+        "path": "/business/manufacturing",
+        "parent_id": "site_1",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      }
+    ],
+    "stock_symbols": [
+      "IBM",
+      "INTL",
+      "AMZN",
+      "MRSFT"
+    ],
+    "additional_properties": {
+      "more": "info"
+    }
+  },
+  "additional_properties": {
+    "foo": "bar"
+  }
+}

--- a/tests/fixtures/schema/0.7.1/story-fixture-good-taxonomy.json
+++ b/tests/fixtures/schema/0.7.1/story-fixture-good-taxonomy.json
@@ -1,0 +1,105 @@
+{
+  "_id": "unique ANS id",
+  "version": "0.7.1",
+  "type": "story",
+  "created_date": "2015-06-24T09:50:50.52Z",
+  "last_updated_date": "2015-06-24T09:50:50.52Z",
+  "channels": ["ios", "android"],
+  "language": "en",
+  "taxonomy": {
+    "associated_tasks": [
+      "5b9a7ffce4b0a981ee6a9897",
+      "5b92bfcbe08ea96cb2fa8cab",
+      "5b92bb3ce08ea96cb2fa8ca4"
+    ],
+    "tags": [
+      {
+        "_id": "fred",
+        "text": "Fred",
+        "slug": "fred",
+        "description": "For all things Fred",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      },
+      {
+        "_id": "writing",
+        "text": "Writing"
+      }
+    ],
+    "keywords": [
+      {
+        "keyword": "Anesthesiologist",
+        "score": 0.77,
+        "frequency": 2
+      }
+    ],
+    "named_entities": [
+      {
+        "_id": "jpmorgan-chase",
+        "name": "JPMorgan Chase",
+        "type": "organization"
+      },
+      {
+        "_id": "barack-obama",
+        "name": "Barack Obama",
+        "type": "person"
+      },
+      {
+        "_id": "washington-dc",
+        "name": "Washington D.C.",
+        "type": "location"
+      }
+    ],
+    "primary_site": {
+      "_id": "site_primary",
+      "type": "site",
+      "version": "0.7.1",
+      "name": "News",
+      "description": "General News",
+      "path": "/news",
+      "additional_properties": {
+        "baz": "bag"
+      }
+    },
+    "sites": [
+      {
+        "_id": "site_1",
+        "type": "site",
+        "version": "0.7.1",
+        "primary": false,
+        "name": "Business",
+        "description": "For all your business needs",
+        "path": "/business",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      },
+      {
+        "_id": "site_2",
+        "type": "site",
+        "version": "0.7.1",
+        "primary": true,
+        "name": "Manufacturing",
+        "description": "For all your manufacturing needs",
+        "path": "/business/manufacturing",
+        "parent_id": "site_1",
+        "additional_properties": {
+          "foo": "bar"
+        }
+      }
+    ],
+    "stock_symbols": [
+      "IBM",
+      "INTL",
+      "AMZN",
+      "MRSFT"
+    ],
+    "additional_properties": {
+      "more": "info"
+    }
+  },
+  "additional_properties": {
+    "foo": "bar"
+  }
+}

--- a/tests/schema-tests-07.js
+++ b/tests/schema-tests-07.js
@@ -552,7 +552,12 @@ describe("Schema: ", function() {
             validate(version, '/story.json', 'story-fixture-bad-wrong-version', false);
           });
 
+          it("should validate a story with valid taxonomy", function() {
+            validateIfFixtureExists(version, '/story.json', 'story-fixture-good-taxonomy');
+          });
+
           it("should not validate a story with bad taxonomy", function() {
+            validateIfFixtureExists(version, '/story.json', 'story-fixture-bad-taxonomy-additional-tasks', false);
             validateIfFixtureExists(version, '/story.json', 'story-fixture-bad-tag-strings', false);
             validateIfFixtureExists(version, '/story.json', 'story-fixture-bad-sections-addl-properties', false);
           });


### PR DESCRIPTION
This is per proposal "task related media", at PR 170. Limit the items to a list of no more than 200 valid WebSked task IDs.