### PR TITLE
EL-2248 propose new html_meta trait

### DIFF
--- a/docs/proposals/2018-11-27-html_meta.md
+++ b/docs/proposals/2018-11-27-html_meta.md
@@ -1,4 +1,4 @@
-# Adding robot_instructions
+# Adding html_meta
 
 # Problem
 
@@ -6,24 +6,21 @@ Currently, there is no dedicated way in ANS to indicate how a standalone content
 
 # Proposal
 
-We propose to add a new trait `robot_instructions` which contains keys as the robot types with a list of instructions for each of the robot.
+We propose to add a new trait `html_meta` which contains name and content pairs to configure meta tags.
 
-### trait_robot_instructions
+### trait_html_meta
 
 ```
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.8.1/traits/trait_robot_instructions.json",
-  "title": "Robot Instructions",
+  "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.8.1/traits/trait_html_meta.json",
+  "title": "HTML meta tag configuration",
   "type": "object",
-  "description": "Lists of instructions for different types of robots",
+  "description": "Lists of configurable name and content pair meta tags",
   "patternProperties": {
-    "^[\w-]+$": {
-      "type": "array",
-      "description": "Instructions for the robot",
-      "items": {
-        "type": "string"
-      }
+    ".+": {
+      "description": "The content value of the meta tag",
+      "type": "string"
     }
   }
 }
@@ -35,16 +32,24 @@ We propose to add a new trait `robot_instructions` which contains keys as the ro
 {
   "type": "story",
   "version": "0.8.1",
-  "robot_instructions": {
-    "googlebot": ["noindex", "nofollow"],
-    "Googlebot-News": ["noindex"]
+  "html_meta": {
+    "googlebot": "noindex, nofollow",
+    "Googlebot-News": "noindex"
   }
 }
 ```
 
+#### Meta Tags
+
+```
+<meta name="googlebot" content="noindex, nofollow">
+<meta name="Googlebot-News" content="noindex">
+```
+
+
 # Concerns
 
-Do we need to be more restrict on the instruction strings using enum noindex, nofollow, none, ...etc (listing all allowed strings)?
+Do we need to be more restrict for the regex pattern of the meta's key value?
 
 # Implementation
 

--- a/docs/proposals/2018-11-27-robot_instructions.md
+++ b/docs/proposals/2018-11-27-robot_instructions.md
@@ -1,0 +1,51 @@
+# Adding robot_instructions
+
+# Problem
+
+Currently, there is no dedicated way in ANS to indicate how a standalone content like story, image, or video should be treated by robots or crawlers. For example, if we need to block a story from appearing in Google search, we need to add a meta tag `<meta name="googlebot" content="noindex">` to prevent Google indexing it. Therefore this proposal is to provide a configurable way for the authoring applications to add instructions for different robots, so the content serving applications can add appropriate meta tags in the content.
+
+# Proposal
+
+We propose to add a new trait `robot_instructions` which contains keys as the robot types with a list of instructions for each of the robot.
+
+### trait_robot_instructions
+
+```
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.8.1/traits/trait_robot_instructions.json",
+  "title": "Robot Instructions",
+  "type": "object",
+  "description": "Lists of instructions for different types of robots",
+  "patternProperties": {
+    "^[\w-]+$": {
+      "type": "array",
+      "description": "Instructions for the robot",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+### Sample Story
+
+```
+{
+  "type": "story",
+  "version": "0.8.1",
+  "robot_instructions": {
+    "googlebot": ["noindex", "nofollow"],
+    "Googlebot-News": ["noindex"]
+  }
+}
+```
+
+# Concerns
+
+Do we need to be more restrict on the instruction strings using enum "noindex" and "nofollow"?
+
+# Implementation
+
+Cheng-Hsin Weng from Ellipsis team will implement this and add it to the schema if this proposal is accepted.

--- a/docs/proposals/2018-11-27-robot_instructions.md
+++ b/docs/proposals/2018-11-27-robot_instructions.md
@@ -44,7 +44,7 @@ We propose to add a new trait `robot_instructions` which contains keys as the ro
 
 # Concerns
 
-Do we need to be more restrict on the instruction strings using enum "noindex" and "nofollow"?
+Do we need to be more restrict on the instruction strings using enum noindex, nofollow, none, ...etc (listing all allowed strings)?
 
 # Implementation
 


### PR DESCRIPTION
Proposing to add a new trait `robot_instructions` for configuring the meta tag instructions for each robot.