### PR TITLE
Update `subtype` trait to accurately reflect usage

### DIFF
--- a/src/main/resources/schema/ans/0.8.1/traits/trait_subtype.json
+++ b/src/main/resources/schema/ans/0.8.1/traits/trait_subtype.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.8.1/traits/trait_subtype.json",
-  "title": "Subtype trait",
+  "title": "Subtype or Template",
   "type": "string",
-  "description": "A more granular type than story, gallery, etc. (E.g., column, blog_post)"
+  "description": "A user-defined categorization method to supplement type. In Arc, this field is reserved for organization-defined purposes, such as selecting the PageBuilder template that should be used to render a document."
 }


### PR DESCRIPTION
In the Arc platform, `subtype` is reserved for client definition and use. This PR updates the ANS trait and description to reflect this fact. 