### PR TITLE
Fixes lib/validator.js to add version 0.9.0

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -15,7 +15,7 @@ var TYPES = [];
 
 var VERSIONS = _.map(
   _.filter(version.history, function (item) {
-    return ["0.5", "0.6", "0.7", "0.8"].some(v => item.name.indexOf(v) > -1);
+    return ["0.5", "0.6", "0.7", "0.8", "0.9"].some(v => item.name.indexOf(v) > -1);
   }),
   function(item) {
     return item.name;


### PR DESCRIPTION
Running the script to create ANS version 0.9.0 did not update the validator.js file. Manually adding it here.