### PR TITLE
Implements schema changes to support tag types and subtypes

### DIFF
--- a/src/main/resources/schema/ans/0.10.2/utils/tag.json
+++ b/src/main/resources/schema/ans/0.10.2/utils/tag.json
@@ -9,6 +9,12 @@
     "_id": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.2/traits/trait_id.json"
     },
+    "type": {
+      "enum": [ "tag" ]
+    },
+    "subtype": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.2/traits/trait_subtype.json"
+    },
     "text": {
       "type": "string",
       "description": "The text of the tag as displayed to users."

--- a/tests/fixtures/schema/0.10.2/story-fixture-good-taxonomy.json
+++ b/tests/fixtures/schema/0.10.2/story-fixture-good-taxonomy.json
@@ -15,6 +15,8 @@
     "tags": [
       {
         "_id": "fred",
+        "type": "tag",
+        "subtype": "basic",
         "text": "Fred",
         "slug": "fred",
         "description": "For all things Fred",
@@ -24,7 +26,11 @@
       },
       {
         "_id": "writing",
+        "subtype": "basic",
         "text": "Writing"
+      },
+      {
+        "text": "Obama"
       }
     ],
     "keywords": [

--- a/tests/fixtures/schema/0.10.2/tag-fixture-bad-no-text.json
+++ b/tests/fixtures/schema/0.10.2/tag-fixture-bad-no-text.json
@@ -1,0 +1,4 @@
+{
+  "type": "tag",
+  "subtype": "basic"
+}

--- a/tests/fixtures/schema/0.10.2/tag-fixture-bad-subtype.json
+++ b/tests/fixtures/schema/0.10.2/tag-fixture-bad-subtype.json
@@ -1,0 +1,4 @@
+{
+  "subtype": null,
+  "text": "news"
+}

--- a/tests/fixtures/schema/0.10.2/tag-fixture-bad-type.json
+++ b/tests/fixtures/schema/0.10.2/tag-fixture-bad-type.json
@@ -1,0 +1,5 @@
+{
+  "type": "label",
+  "subtype": "basic",
+  "text": "news"
+}

--- a/tests/fixtures/schema/0.10.2/tag-fixture-good.json
+++ b/tests/fixtures/schema/0.10.2/tag-fixture-good.json
@@ -1,0 +1,6 @@
+{
+  "type": "tag",
+  "subtype": "basic",
+  "text": "Washington",
+  "_id": "washington"
+}

--- a/tests/schema-tests-010.js
+++ b/tests/schema-tests-010.js
@@ -597,6 +597,18 @@ describe("Schema: ", function() {
           });
         });
 
+        describe("Tag", function() {
+          it("should validate a tag", function() {
+            validateIfFixtureExists(version, "/utils/tag.json", "tag-fixture-good", true);
+          });
+
+          it("should not validate invalid tags", function() {
+            validateIfFixtureExists(version, '/utils/tag.json', 'tag-fixture-bad-no-text', false);
+            validateIfFixtureExists(version, '/utils/tag.json', 'tag-fixture-bad-subtype', false);
+            validateIfFixtureExists(version, '/utils/tag.json', 'tag-fixture-bad-type', false);
+          });
+        });
+
         describe("Image", function() {
           it("should validate a valid image", function() {
             validate(version, '/image.json', 'image-fixture-good');
@@ -1168,9 +1180,8 @@ describe("Schema: ", function() {
           });
         });
 
-        describe("Misc bug fixes", function() {
 
-        });
+
 
         describe("Promo Items", function() {
           it("should allow raw_html item type under basic and any abitrary key", function() {


### PR DESCRIPTION
Implements schema changes to support tag types and subtypes

* `subtype` added per proposal
* `type` added (since subtype makes little sense without it)
* Both are optional, to preserve backwards-compatibility
* tests