### PR TITLE
0.10.9 Release

### DIFF
--- a/src/main/resources/schema/ans/0.10.9/author_operation.json
+++ b/src/main/resources/schema/ans/0.10.9/author_operation.json
@@ -42,7 +42,7 @@
 
       "body": {
         "description": "The object being inserted/updated/deleted",
-        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/utils/author.json"
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/utils/author.json"
       }
     },
     "required": [ "type", "operation", "id", "organization_id" ]

--- a/src/main/resources/schema/ans/0.10.9/site_operation.json
+++ b/src/main/resources/schema/ans/0.10.9/site_operation.json
@@ -42,7 +42,7 @@
 
       "body": {
         "description": "The object being inserted/updated/deleted",
-        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/utils/site.json"
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/utils/site.json"
       }
     },
     "required": [ "type", "operation", "id", "organization_id" ]

--- a/src/main/resources/schema/ans/0.10.9/story_elements/custom_embed.json
+++ b/src/main/resources/schema/ans/0.10.9/story_elements/custom_embed.json
@@ -56,8 +56,19 @@
           "type": "object",
 
           "additionalProperties": false,
+          "properties": {
+            "referent": {
+              "not": {}
+            },
+            "type": {
+              "not": {}
+            },
+            "version": {
+              "not": {}
+            }
+          },
           "patternProperties": {
-            "^(?!(referent|type|version)$)[a-zA-Z0-9_]*$": {}
+            "^([a-zA-Z0-9_])*$": {}
           }
         }
       },

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_id.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_id.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_id.json",
   "title": "Globally Unique ID trait",
-  "description": "Trait that applies a globally unique id.",
   "description": "A globally unique identifier of the content in the ANS repository.",
   "type": "string"
 }

--- a/src/main/resources/schema/ans/0.10.9/video_operation.json
+++ b/src/main/resources/schema/ans/0.10.9/video_operation.json
@@ -42,7 +42,7 @@
 
       "body": {
         "description": "The object being inserted/updated/deleted",
-        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.5.3/video.json"
+        "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/video.json"
       }
     },
     "required": [ "type", "operation", "id", "organization_id" ]


### PR DESCRIPTION
The ANS Schema violates parts of the draft04 specification which makes it unparsable by many JSON Schema parsers.  This change is directly related to the Publishing Platform Team's work on generating application models from the ANS JSON Schema, see [this PR](https://github.com/WPMedia/arcpub/pull/1062) for more context.  The changes in this PR are backwards compatible and the updates to the tests in this PR prove it.