### PR TITLE
Add Auth & SEO Filename traits to image ANS

### DIFF
--- a/src/main/resources/schema/ans/0.10.9/image.json
+++ b/src/main/resources/schema/ans/0.10.9/image.json
@@ -140,7 +140,12 @@
     "focal_point": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_focal_point.json"
     },
-
+    "auth": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json"
+    },
+    "seo_filename": {
+      "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json"
+    },
     "additional_properties": {
       "$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_additional_properties.json"
     },

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json",
+    "title": "Auth",
+    "description": "Mapping of integers to tokens, where the integer represents the Signing Service's secret version in SSM, and token represents an object's public key for usage on the frontend.",
+    "type": "object",
+    "properties": {
+        "/": {}
+    },          
+    "patternProperties": {
+        "^\\d+$": {"type": "string", "pattern": "^\\w{64}$"}
+    },
+    "additionalProperties": false
+}
+  

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
@@ -6,10 +6,9 @@
     "type": "object",
     "properties": {
         "/": {}
-    },          
+    },
     "patternProperties": {
         "^\\d+$": {"type": "string", "pattern": "^\\w{64}$"}
     },
     "additionalProperties": false
 }
-  

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
@@ -4,9 +4,6 @@
     "title": "Auth",
     "description": "Mapping of integers to tokens, where the integer represents the Signing Service's secret version, and token represents an object's public key for usage on the frontend.",
     "type": "object",
-    "properties": {
-        "/": {}
-    },
     "patternProperties": {
         "^\\d+$": {"type": "string", "pattern": "^\\w{64}$"}
     },

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_auth.json",
     "title": "Auth",
-    "description": "Mapping of integers to tokens, where the integer represents the Signing Service's secret version in SSM, and token represents an object's public key for usage on the frontend.",
+    "description": "Mapping of integers to tokens, where the integer represents the Signing Service's secret version, and token represents an object's public key for usage on the frontend.",
     "type": "object",
     "properties": {
         "/": {}

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json",
+    "title": "SEO Filename",
+    "description": "Human-friendly filename used by PageBuilder & Resizer to improve image SEO scoring.",
+    "type": "string"
+  }
+  

--- a/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json
+++ b/src/main/resources/schema/ans/0.10.9/traits/trait_seo_filename.json
@@ -4,5 +4,4 @@
     "title": "SEO Filename",
     "description": "Human-friendly filename used by PageBuilder & Resizer to improve image SEO scoring.",
     "type": "string"
-  }
-  
+}

--- a/tests/fixtures/schema/0.10.9/image-fixture-bad-auth-format.json
+++ b/tests/fixtures/schema/0.10.9/image-fixture-bad-auth-format.json
@@ -5,7 +5,7 @@
   "channels": ["web", "print"],
   "created_date": "2015-06-25T09:50:50.52Z",
   "auth": {
-    "1": "d63ebc8a0ef58bea24af72d169dc12681ad0efcb8c2282d8eddafc0a77df39e3"
+    "1": "aaaaaaaaaaaaa"
   },
   "credits": {
     "by": [

--- a/tests/schema-tests-010.js
+++ b/tests/schema-tests-010.js
@@ -633,6 +633,9 @@ describe("Schema: ", function() {
           it("should not validate an image with focal point data with invalid prop name", function() {
             validateIfFixtureExists(version, '/image.json', 'image-fixture-bad-focal-point-bad-prop-name', false);
           });
+          it("should not validate an image with an auth object that is incorrectly formatted", function() {
+            validateIfFixtureExists(version, '/image.json', 'image-fixture-bad-auth-format', false);
+          });
         });
 
         describe("Image Operation", function() {


### PR DESCRIPTION
This PR implements the Auth & SEO Filename fields proposed by https://github.com/washingtonpost/ans-schema/pull/258.