### PR TITLE
PSTK-2919: added trigger type

### DIFF
--- a/src/main/resources/schema/ans/0.10.9/content_operation.json
+++ b/src/main/resources/schema/ans/0.10.9/content_operation.json
@@ -59,7 +59,7 @@
             "title": "Trigger Type",
             "description": "The type of update that was consumed in order to produce this update. If this operation is the result of a referent update, than this type may or may not match the type of document in the body. For example, suppose story A contains image B and story C. If B is updated, then an operation may be produced with source 'image' and a body of story A (with updated image metadata.) If C is updated, then an operation may be produced with source 'story' and the body of story A.",
             "type": "string",
-            "enum": [ "story", "gallery", "image", "video", "url", "site", "author", "clavis" ]
+            "enum": [ "story", "gallery", "image", "video", "url", "site", "author", "clavis", "variant" ]
           },
           "id": {
             "title": "Trigger ID",


### PR DESCRIPTION
### Ticket: 
https://arcpublishing.atlassian.net/browse/PSTK-2919

### Description: 
- trigger type `variant`  needs to be added for supporting new events which are triggered from denormalizer to downstream
- these new variant triggered story events are to communicate that the story content has been changed for cache busting and partner producers.

[PSTK-2919]: https://arcpublishing.atlassian.net/browse/PSTK-2919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ