### PR TITLE
ACMS-000: release fix for schema loading function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,10 @@
 # ANS Release Notes
+
+### 1.12.3
+
+* Prevent the callback function from being called twice during the loading of schemas
+* Prevent the load schema function from returning before the full schema is read
+
 ### 1.12.2 
 
 * [PPA-825](https://arcpublishing.atlassian.net/browse/PPA-825) - fix a minor issue in previous 1.12.1

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -21,11 +21,10 @@ var loadSchema = function loadSchema(version, done) {
 
   if (_.isObject(schemasByVersion[version])) {
     done(null, schemasByVersion[version]);
+    return;
   }
 
-  var schemaDir = baseDir + '/' + version;
-
-  schemasByVersion[version] = {};
+  var schemaDir = baseDir + '/' + version;  
 
   dir.readFiles(
     schemaDir, {
@@ -33,7 +32,9 @@ var loadSchema = function loadSchema(version, done) {
     },
     function(err, content, filename, next) {
       if (err) throw err;
-
+      if (!schemasByVersion[version]) {
+        schemasByVersion[version] = {};
+      }
       var name = path.relative(schemaDir, filename);
       try {
         var content = JSON.parse(content);

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const schemaVersionsLoaded = {};
 var schemas = {};
 var schemasByVersion = {};
 var dir = require('node-dir');
@@ -8,7 +9,6 @@ var _ = require('lodash');
 
 var baseDir = path.join(path.dirname(module.filename), '../src/main/resources/schema/ans');
 
-var callback = undefined;
 var loaded = false;
 
 
@@ -19,7 +19,7 @@ var loadSchema = function loadSchema(version, done) {
     return;
   }
 
-  if (_.isObject(schemasByVersion[version])) {
+  if (schemasByVersion[version] && schemaVersionsLoaded[version]) {
     done(null, schemasByVersion[version]);
     return;
   }
@@ -34,6 +34,7 @@ var loadSchema = function loadSchema(version, done) {
       if (err) throw err;
       if (!schemasByVersion[version]) {
         schemasByVersion[version] = {};
+        schemaVersionsLoaded[version] = false;
       }
       var name = path.relative(schemaDir, filename);
       try {
@@ -52,7 +53,7 @@ var loadSchema = function loadSchema(version, done) {
           return;
         }
       }
-      loaded = true;
+      schemaVersionsLoaded[version] = true;
       if (typeof done == 'function') {
         done(null, schemasByVersion[version]);
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@washingtonpost/ans-schema",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@washingtonpost/ans-schema",
   "description": "The Washington Post's Arc Native Specification",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "homepage": "https://github.com/washingtonpost/ans-schema",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These changes: 
* Prevent the callback function from being called twice during the loading of schemas
* Prevent the load schema function from returning before the full schema is read