### PR TITLE
ACMS-1317: Adding pattern to validate URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # ANS Release Notes
 
+### 1.12.5
+* [ACMS-1317](https://arcpublishing.atlassian.net/browse/ACMS-1317) - Adding pattern for External Canonical URL Support
+
 ### 1.12.4
 * [ACMS-1783](https://arcpublishing.atlassian.net/browse/ACMS-1783) - External Canonical URL Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@washingtonpost/ans-schema",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@washingtonpost/ans-schema",
   "description": "The Washington Post's Arc Native Specification",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "homepage": "https://github.com/washingtonpost/ans-schema",
   "repository": {
     "type": "git",

--- a/src/main/resources/schema/ans/0.10.11/traits/trait_canonical_url_external.json
+++ b/src/main/resources/schema/ans/0.10.11/traits/trait_canonical_url_external.json
@@ -4,5 +4,5 @@
   "title": "Canonical External URL",
   "description": "The absolute URL of the document on website which will override any relative URL specified by the `canonical_url` field.",
   "type": "string",
-  "pattern": "^https?:\\/\\/([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}(\\/[a-zA-Z0-9\\-._~:/%]+)*$"
+  "pattern": "^https?:\\/\\/[^\\s]*$"
 }

--- a/src/main/resources/schema/ans/0.10.11/traits/trait_canonical_url_external.json
+++ b/src/main/resources/schema/ans/0.10.11/traits/trait_canonical_url_external.json
@@ -3,5 +3,6 @@
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.11/traits/trait_canonical_url_external.json",
   "title": "Canonical External URL",
   "description": "The absolute URL of the document on website which will override any relative URL specified by the `canonical_url` field.",
-  "type": "string"
+  "type": "string",
+  "pattern": "^https?:\\/\\/([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}(\\/[a-zA-Z0-9\\-._~:/%]+)*$"
 }

--- a/src/main/resources/schema/ans/0.10.12/traits/trait_canonical_url_external.json
+++ b/src/main/resources/schema/ans/0.10.12/traits/trait_canonical_url_external.json
@@ -4,5 +4,5 @@
   "title": "Canonical External URL",
   "description": "The absolute URL of the document on website which will override any relative URL specified by the `canonical_url` field.",
   "type": "string",
-  "pattern": "^https?:\\/\\/([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}(\\/[a-zA-Z0-9\\-._~:/%]+)*$"
+  "pattern": "^https?:\\/\\/[^\\s]*$"
 }

--- a/src/main/resources/schema/ans/0.10.12/traits/trait_canonical_url_external.json
+++ b/src/main/resources/schema/ans/0.10.12/traits/trait_canonical_url_external.json
@@ -3,5 +3,6 @@
   "id": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.10.12/traits/trait_canonical_url_external.json",
   "title": "Canonical External URL",
   "description": "The absolute URL of the document on website which will override any relative URL specified by the `canonical_url` field.",
-  "type": "string"
+  "type": "string",
+  "pattern": "^https?:\\/\\/([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}(\\/[a-zA-Z0-9\\-._~:/%]+)*$"
 }


### PR DESCRIPTION
This pull request introduces a new pattern validation for external canonical URLs in the ANS schema and updates the version to `1.12.5`. The key changes include adding a regex pattern for external canonical URLs, ensuring they follow a valid URL structure, and updating the release notes and package version accordingly.

### Schema Enhancements:
* Added a regex pattern to validate the structure of external canonical URLs in `trait_canonical_url_external.json` for both schema versions `0.10.11` and `0.10.12`. This ensures that the `canonical_url` field adheres to a valid URL format. [[1]](diffhunk://#diff-4f23e243d403e39090b19b3dc58889e561b19a1bcb561ea0777a8d080811cc86L6-R7) [[2]](diffhunk://#diff-c1cf9cb47b238dd0c15334a16f6fb43a5d779418e925eaabfb1a1017e8613fd0L6-R7)

### Versioning and Documentation:
* Updated `package.json` to increment the version from `1.12.4` to `1.12.5`.
* Added a new entry in `RELEASE_NOTES.md` for version `1.12.5`, documenting the addition of the pattern for external canonical URL support.